### PR TITLE
Simplify library loading

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  INSTALL_DIR: ${{ github.workspace }}/installs
+
 concurrency:
   group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
   cancel-in-progress: true
@@ -28,6 +31,8 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
+        default: true
+        profile: minimal
 
     - name: Install Ruby
       uses: ruby/setup-ruby@v1
@@ -41,12 +46,10 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get -y install libbotan-2-dev cmake make g++
-        echo "CFM_HASH_BOTAN_PLUGIN_PATH=$PWD/confium-plugin-botan-build/libcfm-hash-botan.so" >> $GITHUB_ENV
     - name: install os-specific build deps and environment (macOS)
       if: runner.os == 'macOS'
       run: |
         brew install botan
-        echo "CFM_HASH_BOTAN_PLUGIN_PATH=$PWD/confium-plugin-botan-build/libcfm-hash-botan.dylib" >> $GITHUB_ENV
     - name: install os-specific build deps and environment (Windows)
       if: runner.os == 'Windows'
       shell: bash
@@ -54,9 +57,9 @@ jobs:
         set -eux
         pacman --noconfirm -S --needed pactoys
         pacboy sync --noconfirm libbotan:p
-        echo "RUBY_DLL_PATH=$(cygpath -w $PWD/confium/target/debug)" >> $GITHUB_ENV
-        echo "CFM_HASH_BOTAN_PLUGIN_PATH=$(cygpath -w $PWD/confium-plugin-botan-build/libcfm-hash-botan.dll)" >> $GITHUB_ENV
         echo "CMAKE_GENERATOR=MSYS Makefiles" >> $GITHUB_ENV
+        echo "$INSTALL_DIR/lib" >> $GITHUB_PATH
+        rustup target add --toolchain nightly-x86_64-pc-windows-msvc x86_64-pc-windows-gnu
 
     - name: Checkout confium core
       uses: actions/checkout@v3
@@ -64,13 +67,15 @@ jobs:
         repository: confium/confium
         path: confium
         fetch-depth: 1
+        submodules: recursive
 
-    - name: Cargo build
-      uses: actions-rs/cargo@v1
-      with:
-        toolchain: nightly
-        command: build
-        args: --manifest-path confium/Cargo.toml
+    - name: Confium build
+      shell: bash
+      run: |
+        mkdir confium-build
+        cd confium-build
+        cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DBUILD_TESTING=off ../confium
+        cmake --build . --target install
 
     - name: Checkout Botan plugin
       uses: actions/checkout@v3
@@ -80,11 +85,12 @@ jobs:
         fetch-depth: 1
 
     - name: Plugin build
+      shell: bash
       run: |
         mkdir confium-plugin-botan-build
         cd confium-plugin-botan-build
-        cmake ../confium-plugin-botan
-        cmake --build .
+        cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ../confium-plugin-botan
+        cmake --build . --target install
 
     - name: Bundle
       run: bundle
@@ -92,8 +98,9 @@ jobs:
     - name: Test
       shell: bash
       run: |
-        export LD_LIBRARY_PATH=$PWD/confium/target/debug
-        export CONFIUM_LIBRARY_PATH=$PWD/confium/target/debug
+        export LD_LIBRARY_PATH=$INSTALL_DIR/lib
+        export DYLD_LIBRARY_PATH=$INSTALL_DIR/lib
+        export RUBY_DLL_PATH=$INSTALL_DIR/lib
         bundle exec rspec
 
   release:

--- a/lib/confium.rb
+++ b/lib/confium.rb
@@ -3,13 +3,6 @@
 require_relative "confium/version"
 
 module Confium
-  # class Error < StandardError; end
-
-  # def self.context
-  #   cfm = Confium::CFM.new
-  #   cfm.load_plugin('botan', ENV['CFM_HASH_BOTAN_PLUGIN_PATH'])
-  #   cfm
-  # end
 
   def self.call_ffi_rc(fn, *args)
     rc = Confium::Lib.method(fn).call(*args)

--- a/lib/confium/cfm.rb
+++ b/lib/confium/cfm.rb
@@ -8,8 +8,6 @@ module Confium
       pptr = FFI::MemoryPointer.new(:pointer)
       Confium.call_ffi(:cfm_create, pptr)
       @ptr = FFI::AutoPointer.new(pptr.read_pointer, self.class.method(:destroy))
-
-      load_plugin('botan', ENV['CFM_HASH_BOTAN_PLUGIN_PATH'])
     end
 
     def self.destroy(ptr)

--- a/lib/confium/lib.rb
+++ b/lib/confium/lib.rb
@@ -2,43 +2,6 @@ require 'ffi'
 
 module Confium
   module Lib
-    # FFI load pattern taken from: ffi-geos
-    # https://github.com/dark-panda/ffi-geos/blob/master/lib/ffi-geos.rb
-    extend FFI::Library
-
-    def self.search_paths
-      @search_paths ||= \
-        if ENV['CONFIUM_LIBRARY_PATH']
-          [ENV['CONFIUM_LIBRARY_PATH']]
-        elsif FFI::Platform::IS_WINDOWS
-          ENV['PATH'].split(File::PATH_SEPARATOR)
-        else
-          [
-            '/usr/local/{lib64,lib}',
-            '/opt/local/{lib64,lib}',
-            '/usr/{lib64,lib}',
-            '/opt/homebrew/lib',
-            '/usr/lib/{x86_64,i386,aarch64}-linux-gnu'
-          ]
-        end
-    end
-
-    def self.find_lib(lib)
-      if ENV['CONFIUM_LIBRARY_PATH'] && File.file?(ENV['CONFIUM_LIBRARY_PATH'])
-        ENV['CONFIUM_LIBRARY_PATH']
-      else
-        Dir.glob(search_paths.map do |path|
-          File.expand_path(File.join(path, "#{lib}.#{FFI::Platform::LIBSUFFIX}{,.?}"))
-        end).first
-      end
-    end
-
-    def self.confium_library_path
-      @confium_library_path ||= \
-        # On MingW the libraries have version numbers
-        find_lib('{lib,}confium{,-?}')
-    end
-
     extend ::FFI::Library
 
     FFI_LAYOUT = {
@@ -55,7 +18,7 @@ module Confium
       cfm_hash_destroy: [ %i[pointer], :void ],
     }.freeze
 
-    ffi_lib(confium_library_path)
+    ffi_lib(%w[confium libconfium])
 
     FFI_LAYOUT.each do |func, ary|
       begin

--- a/spec/confium_digest_spec.rb
+++ b/spec/confium_digest_spec.rb
@@ -11,7 +11,7 @@ require_relative "spec_helper"
 RSpec.describe Confium::Digest do
   let(:cfm) do
     cfm = Confium::CFM.new
-    # cfm.load_plugin('botan', ENV['CFM_HASH_BOTAN_PLUGIN_PATH'])
+    cfm.load_plugin('botan', 'cfm-hash-botan')
     cfm
   end
 


### PR DESCRIPTION
It didn't seem right to me to have hardcoded platform-specific paths and to be mucking about with the OS provisions for shared library loading too much