### PR TITLE
refactor: replace require_relative with autoload

### DIFF
--- a/lib/confium.rb
+++ b/lib/confium.rb
@@ -1,22 +1,38 @@
 # frozen_string_literal: true
 
-require_relative "confium/version"
-
+# Confium is the Ruby entry point for the Confium cryptographic framework.
+#
+# This file opens the {Confium} module and registers an autoload entry for
+# each top-level child constant. Per the project's global rules there is no
+# `require_relative` anywhere in `lib/`: every child is loaded lazily on
+# first reference via Ruby's `autoload` mechanism, so each namespace owns
+# the load paths of its own children.
+#
+# New top-level constants (Cipher, AEAD, KDF, RNG, Signature, KEM, Keyfmt,
+# Keystore, Sensitive, ...) should be added here as one `autoload` line as
+# the backing files land. This keeps the file open for extension (OCP)
+# without touching existing entries.
 module Confium
+  autoload :VERSION,  "confium/version"
+  autoload :FFI,      "confium/ffi"
+  autoload :Crypto,   "confium/crypto"
+  autoload :Lib,      "confium/lib"
+  autoload :CFM,      "confium/cfm"
+  autoload :Digest,   "confium/digest"
 
+  # Invoke an FFI function that returns a uint32 status code, raising when
+  # the call did not succeed (non-zero return).
   def self.call_ffi_rc(fn, *args)
     rc = Confium::Lib.method(fn).call(*args)
     raise "FFI call to #{fn} failed (rc: #{rc})" unless rc.zero?
+
     rc
   end
 
+  # Invoke an FFI function that returns a uint32 status code, discarding
+  # the return value. Raises on non-zero status.
   def self.call_ffi(fn, *args)
     call_ffi_rc(fn, *args)
     nil
   end
-
 end
-
-require_relative 'confium/lib'
-require_relative 'confium/cfm'
-require_relative 'confium/digest'

--- a/lib/confium/cfm.rb
+++ b/lib/confium/cfm.rb
@@ -5,9 +5,9 @@ module Confium
     attr_reader :ptr
 
     def initialize
-      pptr = FFI::MemoryPointer.new(:pointer)
+      pptr = ::FFI::MemoryPointer.new(:pointer)
       Confium.call_ffi(:cfm_create, pptr)
-      @ptr = FFI::AutoPointer.new(pptr.read_pointer, self.class.method(:destroy))
+      @ptr = ::FFI::AutoPointer.new(pptr.read_pointer, self.class.method(:destroy))
     end
 
     def self.destroy(ptr)

--- a/lib/confium/crypto.rb
+++ b/lib/confium/crypto.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# {Confium::Crypto} is the registry namespace for Confium's cryptographic
+# interfaces.
+#
+# Mirroring the Rust plugin-interface registry (TODO #02), each Ruby
+# interface module (Digest, and future Cipher, AEAD, KDF, RNG, Signature,
+# KEM, ...) registers itself here on load rather than being enumerated in
+# a central case statement. This keeps the registry open for extension
+# (OCP) and makes the set of available interfaces a single source of
+# truth.
+#
+# Example:
+#
+#   module Confium
+#     module Digest
+#       Confium::Crypto.register(:hash, self)
+#     end
+#   end
+#
+#   Confium::Crypto.lookup(:hash)  # => Confium::Digest
+module Confium
+  module Crypto
+    @interfaces = {}
+
+    class << self
+      # Register an interface +klass+ under the symbolic +name+. Adding a
+      # new interface is a one-line registration; no central switch needs
+      # editing.
+      def register(name, klass)
+        @interfaces[name] = klass
+        klass
+      end
+
+      # Resolve a registered interface by +name+. Raises ArgumentError if
+      # nothing has been registered under that name.
+      def lookup(name)
+        @interfaces.fetch(name) do
+          raise ArgumentError, "unknown interface #{name.inspect}"
+        end
+      end
+
+      # Enumerate the names of every registered interface. Primarily for
+      # introspection and tooling.
+      def interfaces
+        @interfaces.keys.dup
+      end
+    end
+  end
+end

--- a/lib/confium/digest.rb
+++ b/lib/confium/digest.rb
@@ -8,19 +8,19 @@ module Confium
 
     def initialize(cfm, name)
       @name = name
-      pptr = FFI::MemoryPointer.new(:pointer)
+      pptr = ::FFI::MemoryPointer.new(:pointer)
       Confium.call_ffi(:cfm_hash_create, cfm.ptr, pptr, name, nil, nil, nil)
       ptr = pptr.read_pointer
       raise if ptr.null?
-      @ptr = FFI::AutoPointer.new(ptr, self.class.method(:destroy))
+      @ptr = ::FFI::AutoPointer.new(ptr, self.class.method(:destroy))
     end
 
     def initialize_copy(source)
       @name = source.name
-      pptr = FFI::MemoryPointer.new(:pointer)
+      pptr = ::FFI::MemoryPointer.new(:pointer)
       Confium.call_ffi(:cfm_hash_clone, source.ptr, pptr)
       ptr = pptr.read_pointer
-      @ptr = FFI::AutoPointer.new(ptr, self.class.method(:destroy))
+      @ptr = ::FFI::AutoPointer.new(ptr, self.class.method(:destroy))
     end
 
     def self.destroy(ptr)
@@ -28,13 +28,13 @@ module Confium
     end
 
     def block_length
-      plength = FFI::MemoryPointer.new(:uint32)
+      plength = ::FFI::MemoryPointer.new(:uint32)
       Confium.call_ffi(:cfm_hash_block_size, @ptr, plength)
       plength.read(:uint32)
     end
 
     def digest_length
-      plength = FFI::MemoryPointer.new(:uint32)
+      plength = ::FFI::MemoryPointer.new(:uint32)
       Confium.call_ffi(:cfm_hash_output_size, @ptr, plength)
       plength.read(:uint32)
     end
@@ -50,7 +50,7 @@ module Confium
     end
 
     def finish
-      buf = FFI::MemoryPointer.new(:uint8, digest_length)
+      buf = ::FFI::MemoryPointer.new(:uint8, digest_length)
       Confium.call_ffi(:cfm_hash_finalize, @ptr, buf, buf.size)
       buf.read_bytes(buf.size)
     end

--- a/lib/confium/ffi.rb
+++ b/lib/confium/ffi.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "ffi"
+
+# {Confium::FFI} is the namespace for everything that touches the native
+# Confium shared library through Ruby-FFI.
+#
+# This file registers autoload entries for the planned FFI helper modules
+# (Library, Error, Options). They are listed in the TODO #14 architecture
+# (see `TODO.finalize/14-ruby-bindings-architecture.md`) and will be added
+# as the bindings grow; until then the autoloads are inert — they only
+# trigger a load when the corresponding constant is first referenced.
+#
+# Note: the legacy FFI library wrapper still lives at `Confium::Lib`
+# (file `confium/lib.rb`) and is autoloaded from `confium.rb`. It will be
+# migrated into `Confium::FFI::Library` in a follow-up.
+module Confium
+  module FFI
+    autoload :Library, "confium/ffi/library"
+    autoload :Error,   "confium/ffi/error"
+    autoload :Options, "confium/ffi/options"
+  end
+end

--- a/lib/confium/lib.rb
+++ b/lib/confium/lib.rb
@@ -25,7 +25,7 @@ module Confium
         class_eval do
           attach_function(func, ary.first, ary.last)
         end
-      rescue FFI::NotFoundError
+      rescue ::FFI::NotFoundError
         # that's okay
       end
     end


### PR DESCRIPTION
## Summary

Replaces every `require_relative` in `lib/` with Ruby `autoload`, per the project's global rule (no `require_relative` for internal library code; each namespace owns the load paths of its own children via `autoload` declared in the immediate parent namespace file).

- Removes the three trailing `require_relative` calls from `lib/confium.rb` and the top-of-file `require_relative "confium/version"`.
- Adds `autoload` entries in `lib/confium.rb` for `:VERSION`, `:FFI`, `:Crypto`, `:Lib`, `:CFM`, `:Digest`.
- Adds two new namespace files so each module owns the autoloads of its own children.

## Files created

- `lib/confium/ffi.rb` — opens `Confium::FFI` and registers autoloads for the planned FFI helper modules (`Library`, `Error`, `Options`). Inert until referenced.
- `lib/confium/crypto.rb` — opens `Confium::Crypto`, a registry namespace for Confium's cryptographic interfaces (mirrors the Rust plugin-interface registry). Provides `register` / `lookup` / `interfaces`.

## Files modified

- `lib/confium.rb` — `require_relative` out, `autoload` in; doc comments added.
- `lib/confium/cfm.rb` — `FFI::*` qualified as `::FFI::*`.
- `lib/confium/digest.rb` — `FFI::*` qualified as `::FFI::*` (6 sites).
- `lib/confium/lib.rb` — `FFI::NotFoundError` qualified as `::FFI::NotFoundError`.

## Namespace shadowing fix

The new `Confium::FFI` module would shadow the `ffi` gem's top-level `FFI` for any unqualified `FFI::*` reference inside `module Confium`. Every such reference is now qualified with the top-level prefix (`::FFI::MemoryPointer`, `::FFI::AutoPointer`, `::FFI::NotFoundError`) so it resolves to the gem, not the new namespace.

## Forbidden-pattern audit

Greps run against `lib/` after the refactor, all returning zero real hits:

- `require_relative` — only a documentation comment mentioning the word, no actual calls.
- `\.send(` — none.
- `instance_variable_set` — none.
- `instance_variable_get` — none.
- `respond_to?` — none.

## Test status

- Smoke test: the autoload graph loads end-to-end (`Confium::FFI`, `Confium::Crypto`, `Confium::Lib`, `Confium::CFM`, `Confium::Digest` all resolve), verified with `DYLD_LIBRARY_PATH` pointing at the built `libconfium.dylib`.
- Existing rspec passes once `libconfium.dylib` is on the dlopen path. The native library not being on the default search path is a pre-existing environment limitation, not something introduced by this refactor.

## Test plan

- [ ] CI green.
- [ ] `bundle exec rspec` passes locally with `libconfium.dylib` on `DYLD_LIBRARY_PATH`.
- [ ] `require "confium"` resolves every autoloaded constant without a `LoadError`.
