### PR TITLE
docs(ecosystem-sync): rewrite README + add module-level spec + ecosystem TODO

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,96 @@
+PATH
+  remote: .
+  specs:
+    confium (0.2.0)
+      ffi
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    diff-lcs (1.6.2)
+    ffi (1.17.4)
+    ffi (1.17.4-arm64-darwin)
+    json (2.21.1)
+    language_server-protocol (3.17.0.6)
+    lint_roller (1.1.0)
+    parallel (2.1.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.4.2)
+    regexp_parser (2.12.0)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+
+PLATFORMS
+  arm64-darwin
+  ruby
+
+DEPENDENCIES
+  confium!
+  rake (~> 13.0)
+  rspec
+  rubocop (~> 1.21)
+
+CHECKSUMS
+  ast (2.4.3)
+  confium (0.2.0)
+  diff-lcs (1.6.2)
+  ffi (1.17.4)
+  ffi (1.17.4-arm64-darwin)
+  json (2.21.1)
+  language_server-protocol (3.17.0.6)
+  lint_roller (1.1.0)
+  parallel (2.1.0)
+  parser (3.3.12.0)
+  prism (1.9.0)
+  racc (1.8.1)
+  rainbow (3.1.1)
+  rake (13.4.2)
+  regexp_parser (2.12.0)
+  rspec (3.13.2)
+  rspec-core (3.13.6)
+  rspec-expectations (3.13.5)
+  rspec-mocks (3.13.8)
+  rspec-support (3.13.7)
+  rubocop (1.88.2)
+  rubocop-ast (1.50.0)
+  ruby-progressbar (1.13.0)
+  unicode-display_width (3.2.0)
+  unicode-emoji (4.2.0)
+
+BUNDLED WITH
+  4.0.16

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,16 @@
 = Confium Ruby bindings
+:toc: macro
+:toclevels: 2
 
-== Purpose
+Ruby bindings for the Confium open-source framework for multi-stakeholder threshold cryptography.
 
-Ruby bindings for Confium.
+Confium supports three deployment modes:
+
+* **Mode 1 — Peer-to-peer threshold cryptography**: nodes do TC directly (MPC, distributed custody, BFT)
+* **Mode 2 — TC PKI replacement**: drop-in for existing PKI consumers (PKCS#11 server, OpenSSL 3.0 provider, JCE)
+* **Mode 3 — TC Certificate PKI**: institutional deployments with custom certificate formats (OIML CNML, BIPM, pharma, accreditation)
+
+This gem wraps the C ABI exposed by Confium's Rust workspace and exposes it through idiomatic Ruby.
 
 == Installation
 
@@ -20,20 +28,76 @@ If bundler is not being used to manage dependencies, install the gem by executin
 $ gem install confium
 ----
 
+== Prerequisites
+
+The gem links against `libconfium.{so,dylib,dll}` from the Rust workspace.
+
+Build it from the https://github.com/confium/confium[`confium` repository]:
+
+[source,sh]
+----
+$ git clone https://github.com/confium/confium.git
+$ cd confium/confium
+$ cargo build --workspace --release
+$ # The library appears at target/release/libconfium.{so,dylib,dll}
+----
+
+Ensure the library is on the system load path (`LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH`, or install to a system location).
+
 == Usage
 
-TODO: Write usage instructions here
+=== Hash (digest computation)
+
+[source,ruby]
+----
+require 'confium'
+
+digest = Confium::Digest.new('sha2-256')
+digest.update('hello, ')
+digest.update('world')
+puts digest.final_hex  # => hex-encoded SHA-256 of "hello, world"
+----
+
+=== Loading plugins
+
+[source,ruby]
+----
+Confium::CFM.load_plugin('/path/to/libcfmp_botan.so')
+----
 
 == Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies.
+Then, run `rake spec` to run the tests. You can also run `bin/console`
+for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
+
+== Project organization
+
+The Confium project spans multiple repositories:
+
+* `confium/confium`:: Rust workspace, the main product (43 crates, 744+ tests)
+* `confium/confium-ruby`:: This gem (Ruby FFI bindings)
+* `confium/confium.github.io`:: Jekyll site for https://www.confium.org
+* `confium/confium-report`:: AsciiDoc technical report
+* `rnpgp/rnp-rs`:: Rust binding to RNP OpenPGP C library (consumed by Confium for PGP operations)
 
 == Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/confium. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/confium/blob/main/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/confium/confium-ruby. This project is intended to be
+a safe, welcoming space for collaboration, and contributors are expected
+to adhere to the
+https://github.com/confium/confium-ruby/blob/main/CODE_OF_CONDUCT.md[code of conduct].
+
+== License
+
+The gem is available as open source under the terms of the
+https://opensource.org/licenses/BSD-2-Clause[BSD-2-Clause License].
 
 == Code of Conduct
 
-Everyone interacting in the Confium project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/confium/blob/main/CODE_OF_CONDUCT.md).
+Everyone interacting in the Confium project's codebases, issue trackers,
+chat rooms, and mailing lists is expected to follow the
+https://github.com/confium/confium-ruby/blob/main/CODE_OF_CONDUCT.md[code of conduct].

--- a/TODO.roadmap/00-ecosystem-sync.md
+++ b/TODO.roadmap/00-ecosystem-sync.md
@@ -1,0 +1,137 @@
+# 00 — Ecosystem synchronization
+
+## Overview
+
+The Confium project spans multiple repositories. This document tracks
+ecosystem-wide synchronization and is the master reference for which
+repos need attention.
+
+## Repositories
+
+### Primary
+
+| Repo | URL | Role | Status |
+|---|---|---|---|
+| `confium` | https://github.com/confium/confium | Rust workspace (main product) | ✅ Active (43 crates, 744+ tests, 69 TODO docs) |
+| `confium-ruby` | https://github.com/confium/confium-ruby | Ruby FFI bindings gem | ✅ Active (this repo) |
+| `confium.github.io` | https://github.com/confium/confium.github.io | Jekyll site for www.confium.org | ✅ Active (three-mode landing shipped) |
+| `confium-report` | https://github.com/confium/confium-report | Multi-spec technical repository (currently 2022 vintage; needs v2 spec docs) | ⚠️ Outdated |
+| `infrastructure` | https://github.com/confium/infrastructure | Terraform for AWS (CONFIDENTIAL) | 🔒 Operator-managed (Ribose ops only) |
+
+### Consumed dependencies
+
+| Repo | URL | Role | Status |
+|---|---|---|---|
+| `rnp-rs` | https://github.com/rnpgp/rnp-rs | Rust binding to RNP OpenPGP C library | ✅ All 3 Confium BUGREPORTs fixed (commit ed268d5) |
+| `hash-botan` | https://github.com/confium/hash-botan | Botan hash plugin (extracted from main) | ✅ Standalone |
+
+### Downstream consumers (not Confium repos)
+
+| Repo | URL | Role |
+|---|---|---|
+| `oimlsmart/digital-certificates` | (private) | OIML CNML project — Mode 3 flagship consumer |
+| `parsanol/parsanol-rs` | https://github.com/parsanol/parsanol-rs | Reference for publishing conventions |
+
+## Synchronization matrix
+
+When the framework changes, downstream repos may need updates:
+
+| Framework change | Ruby | Site | Report (specs) | CNML |
+|---|---|---|---|---|
+| Public FFI surface | Update lib/confium/ffi.rb | Docs only | Spec doc update | Compile against new |
+| New crate published | Add bindings if user-facing | Mention in features | Mention in spec | Use as needed |
+| Architecture shift (e.g., three-mode) | README update | Landing page update | New spec document | Strategy alignment |
+| Version bump | Bump gem version | Docs only | Optional | Update dependency |
+| Crate consolidation (rename) | Update FFI paths | Update feature list | Update spec refs | Update imports |
+
+## Recent synchronization work
+
+### 2026-07-26: Three-mode architecture rollout
+
+Triggered by framework reaching 43 crates + 744 tests + Mode 1/2/3 framing.
+
+- ✅ `confium.github.io`: PR #11 merged — landing page now describes three modes
+- ✅ `confium-ruby`: this branch — README rewritten with three-mode context, added `confium_spec.rb` for module-level coverage
+- ⏳ `confium-report`: needs to be generalized into a multi-spec repository (per direction from Ribose)
+- ⏭️ `infrastructure`: not affected (operator-managed)
+
+### 2026-07-26: Crate consolidation (53 → 43)
+
+Triggered by 5 logical merges.
+
+- ✅ `confium`: 5 PRs merged (#42, #43), tests preserved (744), CLAUDE.md updated
+- ✅ `confium-ruby`: not affected (no Ruby bindings to deleted crates)
+- ✅ `confium.github.io`: not affected (no per-crate pages yet)
+- ⏳ `confium-report`: should reference new consolidated crate names
+
+## Per-repo TODO
+
+### confium-ruby (this repo)
+
+- [x] README rewrite (DONE this branch)
+- [x] Add `spec/confium_spec.rb` for module-level coverage (DONE this branch)
+- [ ] Bump gem version to 0.3.0 to match Rust workspace
+- [ ] Add bindings for new interfaces: `confium-tc` (threshold signing), `confium-tc-kem` (threshold encryption), `confium-coordinator` (async session)
+- [ ] Add integration test that builds Rust workspace and runs against gem
+- [ ] Translate high-level framework docs into Ruby-idiomatic examples
+
+### confium.github.io
+
+- [x] Three-mode landing (DONE)
+- [x] About page rewrite (DONE)
+- [ ] Blog post: "Confium 0.3 released — three deployment modes"
+- [ ] Documentation portal at docs.confium.org (links to RustDoc + examples)
+- [ ] CNML case study page (summary of `TODO.roadmap/27-cnml-deployment.md`)
+- [ ] NIST MPTS page (summary of `TODO.roadmap/25-nist-threshold-call.md`)
+
+### confium-report (to be generalized into multi-spec repository)
+
+This repository is being **generalized into a multi-spec repository** covering all aspects of how Confium works and the various systems Confium provides. Specs include:
+
+- Architecture overview (three-mode framework)
+- Mode 1 (peer-to-peer threshold crypto) specification
+- Mode 2 (TC PKI replacement) specification
+- Mode 3 (TC Certificate PKI) specification
+- Plugin contract specification
+- Async session coordinator specification
+- Share re-sharing protocol specification
+- Threshold encryption interface specification
+- Composite signatures specification
+- Transparency log specification
+- Identity / hardware interface specification
+- Deployment manifest specification
+
+Each spec includes:
+- Conceptual overview
+- Architectural diagram (SVG)
+- Type definitions / API surface
+- Wire formats (DER, JSON, TOML)
+- Behavioral invariants
+- Test vectors
+- Cross-references to TODO.roadmap/
+
+Existing 2022 `report.adoc` is preserved as historical context but no longer
+the canonical technical reference.
+
+### infrastructure (operator-managed)
+
+DO NOT TOUCH without Ribose operator approval. See repo's own `README.adoc`.
+
+Future operator-initiated work (when CNML deploys):
+- DNS for `learn.confium.org`, `docs.confium.org`, `log.confium.org`
+- Coordinator hosting (BIML-operated)
+- Transparency log infrastructure
+- S3 buckets for transparency log data
+
+## Anti-goals
+
+- **Not** forcing sync across all repos on every framework change — only when user-facing
+- **Not** modifying `infrastructure` without operator approval (per CLAUDE.md)
+- **Not** auto-generating bindings from Rust FFI surface (manual curation preferred for now)
+
+## References
+
+- `/Users/mulgogi/src/confium/CLAUDE.md` (workspace-level)
+- `confium/TODO.roadmap/26-confium-framework.md` (framework vision)
+- `confium/TODO.roadmap/65-project-governance.md` (project governance)
+- `confium/TODO.roadmap/68-roadmap-timeline.md` (multi-year phases)

--- a/spec/confium_spec.rb
+++ b/spec/confium_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Confium do
+  describe "VERSION" do
+    it "is defined" do
+      expect(Confium::VERSION).not_to be_nil
+    end
+
+    it "is a string" do
+      expect(Confium::VERSION).to be_a(String)
+    end
+
+    it "follows semver format" do
+      expect(Confium::VERSION).to match(/^\d+\.\d+\.\d+/)
+    end
+  end
+
+  describe "module structure" do
+    it "defines Confium as a module" do
+      expect(Confium).to be_a(Module)
+    end
+
+    it "autoloads FFI on first reference" do
+      expect { Confium::FFI }.not_to raise_error
+    end
+
+    it "autoloads Lib on first reference" do
+      expect { Confium::Lib }.not_to raise_error
+    end
+
+    it "autoloads CFM on first reference" do
+      expect { Confium::CFM }.not_to raise_error
+    end
+
+    it "autoloads Digest on first reference" do
+      expect { Confium::Digest }.not_to raise_error
+    end
+
+    it "autoloads Crypto on first reference" do
+      expect { Confium::Crypto }.not_to raise_error
+    end
+  end
+
+  describe ".call_ffi_rc" do
+    it "is defined as a class method" do
+      expect(Confium.respond_to?(:call_ffi_rc)).to be(true)
+    end
+  end
+
+  describe ".call_ffi" do
+    it "is defined as a class method" do
+      expect(Confium.respond_to?(:call_ffi)).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Brings the Ruby gem repo in sync with the framework's three-mode architecture, adds module-level specs, and tracks ecosystem-wide synchronization.

### README.adoc rewrite

- Replaces TODO placeholders with current positioning
- Adds three-mode architecture overview (Mode 1 / Mode 2 / Mode 3)
- Documents build prerequisites (`libconfium.{so,dylib,dll}` from Rust workspace)
- Ruby usage examples (Digest computation, plugin loading)
- "Project organization" section listing all Confium repos with their roles
- Fixes `[USERNAME]` placeholder URLs in Contributing and Code of Conduct sections

### `spec/confium_spec.rb` (new)

- `Confium::VERSION` is defined, is a string, follows semver format
- Module structure specs: `autoload` correctly resolves FFI, Lib, CFM, Digest, Crypto submodules on first reference
- Class method presence: `.call_ffi_rc`, `.call_ffi`

### `TODO.roadmap/00-ecosystem-sync.md` (new)

Master reference for ecosystem-wide synchronization work:

- Repository inventory (5 Confium repos + RNP-rs + downstream consumers with roles and status)
- Synchronization matrix: which framework changes trigger updates in which repo
- Recent sync work log (three-mode rollout, crate consolidation)
- Per-repo TODO: Ruby gem (this repo), website (DONE), multi-spec report repo (in progress), infrastructure (operator-managed)
- Notes that `confium-report` is being generalized into a multi-spec repository covering all Confium systems with SVG diagrams

## Test plan

- [x] README renders as valid AsciiDoc
- [x] Specs load and run without errors
- [x] TODO doc accurately reflects current ecosystem state
- [x] Conventional commit message
- [x] No AI attribution trailers
