### PR TITLE
feat(native-ext): add Composite + Attributes subsystems (Phase 1B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,24 +212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "confium-pki"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d591d0b6b643edf35c656e25a6524aeb50201889994a9a851fb8605a577b4e8"
-dependencies = [
- "chrono",
- "data-encoding",
- "der",
- "serde",
- "serde_json",
- "sha2",
- "snafu",
- "spki",
- "thiserror",
- "x509-cert",
-]
-
-[[package]]
 name = "confium-transparency"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,9 +234,10 @@ dependencies = [
  "confium-attributes",
  "confium-composite",
  "confium-core",
- "confium-pki",
  "confium-transparency",
+ "ed25519-dalek",
  "magnus",
+ "rand_core",
  "rb-sys",
  "sha2",
 ]
@@ -340,21 +323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "der_derive",
- "flagset",
- "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -409,12 +378,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flagset"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "futures-core"
@@ -658,15 +621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,17 +841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,27 +967,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "tls_codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
-dependencies = [
- "tls_codec_derive",
- "zeroize",
-]
-
-[[package]]
-name = "tls_codec_derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1225,20 +1147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "x509-cert"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
-dependencies = [
- "const-oid",
- "der",
- "sha1",
- "signature",
- "spki",
- "tls_codec",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,20 +1171,6 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "zmij"

--- a/ext/confium_native/Cargo.toml
+++ b/ext/confium_native/Cargo.toml
@@ -27,11 +27,12 @@ magnus = { version = "0.8", features = ["bytes"] }
 # an extension whose behavior matches the Rust library of the same version.
 confium-core = "0.2"
 confium-transparency = "0.3"
-confium-pki = "0.3"
 confium-composite = "0.3"
 confium-attributes = "0.3"
 
-# Required by transparency (chrono is re-exported via the crate).
+ed25519-dalek = { version = "2", features = ["rand_core"] }
+rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+
 sha2 = "0.10"
 
 [profile.release]

--- a/ext/confium_native/src/attributes.rs
+++ b/ext/confium_native/src/attributes.rs
@@ -1,0 +1,88 @@
+//! Confium::Attributes — Ruby surface for `confium_attributes`.
+//!
+//! Exposes the predicate DSL + evaluator for threshold-signing attribute
+//! policies (e.g., "5-of-9 directors, spanning 3 regions").
+//!
+//!   - `Confium::Attributes.parse(expr)` — parse a DSL string into a
+//!     `Confium::Attributes::Predicate`.
+//!   - `Confium::Attributes::Predicate#satisfied_by?(signers)` — evaluate
+//!     against a list of `Confium::Attributes::Signer`.
+//!   - `Confium::Attributes::Signer` — a signer's attribute map, with
+//!     `#add(key, value)`, `#has?(key)`, `#values(key)`.
+
+use confium_attributes::{evaluate, parse as dsl_parse, Predicate, SignerAttributes};
+use magnus::{
+    exception, function, method, prelude::*, typed_data::Obj, DataTypeFunctions, Error, Module,
+    Object, Ruby, TryConvert, TypedData, Value,
+};
+
+#[derive(TypedData, DataTypeFunctions)]
+#[magnus(class = "Confium::Attributes::Predicate", size)]
+pub struct PredicateWrap {
+    pub inner: Predicate,
+}
+
+impl PredicateWrap {
+    fn satisfied_by(&self, signers_value: Value) -> Result<bool, Error> {
+        let arr = magnus::RArray::try_convert(signers_value)?;
+        let mut owned: Vec<SignerAttributes> = Vec::with_capacity(arr.len());
+        for v in arr.each() {
+            let signer_wrap = Obj::<SignerWrap>::try_convert(v?)?;
+            owned.push(signer_wrap.inner.borrow().clone());
+        }
+        let refs: Vec<&SignerAttributes> = owned.iter().collect();
+        Ok(evaluate(&self.inner, &refs))
+    }
+}
+
+#[derive(TypedData, DataTypeFunctions)]
+#[magnus(class = "Confium::Attributes::Signer", size)]
+pub struct SignerWrap {
+    pub inner: std::cell::RefCell<SignerAttributes>,
+}
+
+impl SignerWrap {
+    fn new() -> Self {
+        Self {
+            inner: std::cell::RefCell::new(SignerAttributes::new()),
+        }
+    }
+
+    fn add(&self, key: String, value: String) {
+        self.inner.borrow_mut().add(key, value);
+    }
+
+    fn has(&self, key: String) -> bool {
+        self.inner.borrow().has(&key)
+    }
+
+    fn values(&self, key: String) -> Vec<String> {
+        self.inner.borrow().values(&key)
+    }
+}
+
+fn parse(expr: String) -> Result<Obj<PredicateWrap>, Error> {
+    let predicate = dsl_parse(&expr)
+        .map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+    let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+    Ok(ruby.obj_wrap(PredicateWrap { inner: predicate }))
+}
+
+pub fn init(ruby: &Ruby, parent: magnus::RModule) -> Result<(), Error> {
+    let attributes = parent.define_module("Attributes")?;
+    attributes.define_module_function("parse", function!(parse, 1))?;
+
+    let pred_class = attributes.define_class("Predicate", ruby.class_object())?;
+    pred_class.define_method(
+        "satisfied_by?",
+        method!(PredicateWrap::satisfied_by, 1),
+    )?;
+
+    let signer_class = attributes.define_class("Signer", ruby.class_object())?;
+    signer_class.define_singleton_method("new", function!(SignerWrap::new, 0))?;
+    signer_class.define_method("add", method!(SignerWrap::add, 2))?;
+    signer_class.define_method("has?", method!(SignerWrap::has, 1))?;
+    signer_class.define_method("values", method!(SignerWrap::values, 1))?;
+
+    Ok(())
+}

--- a/ext/confium_native/src/composite.rs
+++ b/ext/confium_native/src/composite.rs
@@ -1,0 +1,197 @@
+//! Confium::Composite — Ruby surface for `confium_composite`.
+//!
+//! Exposes PQ-migration composite signatures (Ed25519 + ML-DSA-65 etc.).
+//!
+//!   - `Confium::Composite::Signature` — a composite signature with multiple
+//!     algorithm components over the same message. Wraps
+//!     `confium_composite::CompositeSignature`.
+//!   - `Confium::Composite.sign_ed25519(private_key_bytes, message)` —
+//!     helper that builds a real Ed25519 component using
+//!     `ed25519_dalek::SigningKey`.
+//!   - `Confium::Composite::VerificationResult` — result of `#verify(message)`,
+//!     with `#all_verified?` and `#per_component` accessors.
+
+use confium_composite::{CompositeSignature, ComponentSignature, VerificationResult};
+use ed25519_dalek::{Signer, SigningKey};
+use magnus::{
+    exception, function, method, prelude::*, typed_data::Obj, DataTypeFunctions, Error, IntoValue,
+    Module, Object, RHash, Ruby, TryConvert, TypedData, Value,
+};
+use rand_core::OsRng;
+
+#[derive(TypedData, DataTypeFunctions)]
+#[magnus(class = "Confium::Composite::Signature", size)]
+pub struct CompositeSig {
+    inner: std::cell::RefCell<CompositeSignature>,
+}
+
+impl CompositeSig {
+    fn new(components: Value) -> Result<Self, Error> {
+        let comps = parse_components(components)?;
+        Ok(Self {
+            inner: std::cell::RefCell::new(CompositeSignature::new(comps)),
+        })
+    }
+
+    fn component_count(&self) -> usize {
+        self.inner.borrow().component_count()
+    }
+
+    fn algorithms(&self) -> Vec<String> {
+        self.inner
+            .borrow()
+            .algorithms()
+            .into_iter()
+            .map(String::from)
+            .collect()
+    }
+
+    fn verify(&self, message: Value) -> Result<Obj<VerificationResultWrap>, Error> {
+        let msg = bytes_from_value(message)?;
+        let result = self
+            .inner
+            .borrow()
+            .verify(&msg, |algorithm, public_key, m, signature| {
+                // Built-in Ed25519 verifier is the only real one currently;
+                // unknown algorithms are reported as failed components.
+                confium_composite::ed25519_verifier(algorithm, public_key, m, signature)
+            })
+            .map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+        let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+        Ok(ruby.obj_wrap(VerificationResultWrap { inner: result }))
+    }
+}
+
+#[derive(TypedData, DataTypeFunctions)]
+#[magnus(class = "Confium::Composite::VerificationResult", size)]
+pub struct VerificationResultWrap {
+    inner: VerificationResult,
+}
+
+impl VerificationResultWrap {
+    fn all_verified(&self) -> bool {
+        self.inner.all_verified
+    }
+
+    fn per_component(&self) -> Result<Value, Error> {
+        let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+        let result = ruby.hash_new();
+        for c in &self.inner.per_component {
+            let entry = ruby.hash_new();
+            entry.aset("algorithm", c.algorithm.clone())?;
+            entry.aset("verified", c.verified)?;
+            if let Some(err) = &c.error {
+                entry.aset("error", err.clone())?;
+            }
+            result.aset(c.index, entry)?;
+        }
+        Ok(result.into_value_with(&ruby))
+    }
+}
+
+/// Build a real Ed25519 component signature.
+///
+/// `Confium::Composite.sign_ed25519(private_key_bytes, message)` returns
+/// a Hash with `algorithm`, `public_key`, `signature` keys.
+fn sign_ed25519(ruby: &Ruby, private_key: Value, message: Value) -> Result<RHash, Error> {
+    let pk_bytes = bytes_from_value(private_key)?;
+    let msg = bytes_from_value(message)?;
+    if pk_bytes.len() != 32 {
+        return Err(Error::new(
+            exception::arg_error(),
+            format!("Ed25519 private key must be 32 bytes, got {}", pk_bytes.len()),
+        ));
+    }
+    let mut pk_arr = [0u8; 32];
+    pk_arr.copy_from_slice(&pk_bytes);
+    let signing = SigningKey::from_bytes(&pk_arr);
+    let component = confium_composite::build_ed25519_component(&signing, &msg)
+        .map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+
+    let result = ruby.hash_new();
+    result.aset("algorithm", component.algorithm)?;
+    result.aset("public_key", bytes_to_rstring(ruby, &component.public_key))?;
+    result.aset("signature", bytes_to_rstring(ruby, &component.signature))?;
+    Ok(result)
+}
+
+/// Generate a fresh Ed25519 keypair.
+///
+/// `Confium::Composite.generate_ed25519_keypair` returns `[private_key, public_key]`
+/// as binary strings (32 bytes each).
+fn generate_ed25519_keypair(ruby: &Ruby) -> Result<RHash, Error> {
+    let mut rng = OsRng;
+    let signing = SigningKey::generate(&mut rng);
+    let verifying = signing.verifying_key();
+    let result = ruby.hash_new();
+    result.aset("private_key", bytes_to_rstring(ruby, &signing.to_bytes()))?;
+    result.aset("public_key", bytes_to_rstring(ruby, &verifying.to_bytes()))?;
+    Ok(result)
+}
+
+fn parse_components(value: Value) -> Result<Vec<ComponentSignature>, Error> {
+    let arr = magnus::RArray::try_convert(value)?;
+    let mut out = Vec::with_capacity(arr.len());
+    for v in arr.each() {
+        let h: RHash = RHash::try_convert(v?)?;
+        let algorithm: String = h.fetch::<_, String>("algorithm")?;
+        let public_key: Value = h.fetch::<_, Value>("public_key")?;
+        let signature: Value = h.fetch::<_, Value>("signature")?;
+        out.push(ComponentSignature {
+            algorithm,
+            public_key: bytes_from_value(public_key)?,
+            signature: bytes_from_value(signature)?,
+        });
+    }
+    Ok(out)
+}
+
+fn bytes_from_value(v: Value) -> Result<Vec<u8>, Error> {
+    use magnus::RString;
+    if let Ok(s) = RString::try_convert(v) {
+        return Ok(unsafe { s.as_slice() }.to_vec());
+    }
+    let arr: Vec<i64> = Vec::<i64>::try_convert(v)?;
+    arr.into_iter()
+        .map(|i| {
+            if !(0..=255).contains(&i) {
+                Err(Error::new(
+                    exception::arg_error(),
+                    format!("byte out of range 0..255: {i}"),
+                ))
+            } else {
+                Ok(i as u8)
+            }
+        })
+        .collect()
+}
+
+fn bytes_to_rstring(_ruby: &Ruby, bytes: &[u8]) -> magnus::RString {
+    let s = magnus::RString::buf_new(0);
+    s.cat(bytes);
+    s
+}
+
+pub fn init(ruby: &Ruby, parent: magnus::RModule) -> Result<(), Error> {
+    let composite = parent.define_module("Composite")?;
+    composite.define_module_function(
+        "sign_ed25519",
+        function!(sign_ed25519, 2),
+    )?;
+    composite.define_module_function(
+        "generate_ed25519_keypair",
+        function!(generate_ed25519_keypair, 0),
+    )?;
+
+    let sig_class = composite.define_class("Signature", ruby.class_object())?;
+    sig_class.define_singleton_method("new", function!(CompositeSig::new, 1))?;
+    sig_class.define_method("component_count", method!(CompositeSig::component_count, 0))?;
+    sig_class.define_method("algorithms", method!(CompositeSig::algorithms, 0))?;
+    sig_class.define_method("verify", method!(CompositeSig::verify, 1))?;
+
+    let result_class = composite.define_class("VerificationResult", ruby.class_object())?;
+    result_class.define_method("all_verified?", method!(VerificationResultWrap::all_verified, 0))?;
+    result_class.define_method("per_component", method!(VerificationResultWrap::per_component, 0))?;
+
+    Ok(())
+}

--- a/ext/confium_native/src/lib.rs
+++ b/ext/confium_native/src/lib.rs
@@ -4,6 +4,8 @@
 //! `rb_sys`, and exposes a `Confium::Native` submodule whose functions
 //! are the Rust-backed implementation of the gem's API.
 
+mod attributes;
+mod composite;
 mod transparency;
 
 use magnus::{function, Error, Module, Ruby};
@@ -33,5 +35,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     confium.define_module_function("core_version", function!(core_version, 0))?;
 
     transparency::init(ruby, confium)?;
+    composite::init(ruby, confium)?;
+    attributes::init(ruby, confium)?;
     Ok(())
 }

--- a/spec/confium/attributes_spec.rb
+++ b/spec/confium/attributes_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "confium"
+
+RSpec.describe Confium::Attributes do
+  describe ".parse" do
+    it "returns a Predicate instance" do
+      pred = described_class.parse(%q{min_count("role:director", 3)})
+      expect(pred).to be_a(described_class::Predicate)
+    end
+
+    it "raises on a malformed expression" do
+      expect {
+        described_class.parse(%q{not_a_function(})
+      }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe Confium::Attributes::Signer do
+    it "starts empty and reports has?/values correctly" do
+      s = described_class.new
+      expect(s.has?("role:director")).to be(false)
+      s.add("role:director", "yes")
+      expect(s.has?("role:director")).to be(true)
+      expect(s.values("role:director")).to eq(["yes"])
+    end
+  end
+
+  describe Confium::Attributes::Predicate do
+    def signer(role: nil, region: nil, **extra)
+      s = Confium::Attributes::Signer.new
+      s.add("role:director", "yes") if role
+      s.add("region", region) if region
+      extra.each { |k, v| s.add(k.to_s, v) }
+      s
+    end
+
+    let(:alice)   { signer(role: true, region: "europe") }
+    let(:bob)     { signer(role: true, region: "americas") }
+    let(:carol)   { signer(role: true, region: "asia-pacific") }
+    let(:non_dir) { signer(region: "europe") }
+
+    it "min_count succeeds when threshold is met" do
+      pred = Confium::Attributes.parse(%q{min_count("role:director", 3)})
+      expect(pred.satisfied_by?([alice, bob, carol])).to be(true)
+    end
+
+    it "min_count fails when threshold is not met" do
+      pred = Confium::Attributes.parse(%q{min_count("role:director", 3)})
+      expect(pred.satisfied_by?([alice, bob])).to be(false)
+    end
+
+    it "min_distinct requires N distinct values" do
+      pred = Confium::Attributes.parse(%q{min_distinct("region", 3)})
+      expect(pred.satisfied_by?([alice, bob, carol])).to be(true)
+      expect(pred.satisfied_by?([alice, bob, alice])).to be(false)
+    end
+
+    it "any requires at least one signer with the attribute" do
+      pred = Confium::Attributes.parse(%q{any("role:director")})
+      expect(pred.satisfied_by?([non_dir, alice])).to be(true)
+      expect(pred.satisfied_by?([non_dir])).to be(false)
+    end
+
+    it "all requires every signer to have the attribute" do
+      pred = Confium::Attributes.parse(%q{all("role:director")})
+      expect(pred.satisfied_by?([alice, bob])).to be(true)
+      expect(pred.satisfied_by?([alice, non_dir])).to be(false)
+    end
+
+    it "none requires no signer to have the attribute" do
+      pred = Confium::Attributes.parse(%q{none("nationality:cn")})
+      expect(pred.satisfied_by?([alice, bob])).to be(true)
+      blocked = signer("nationality:cn": "yes")
+      expect(pred.satisfied_by?([alice, blocked])).to be(false)
+    end
+
+    it "composes via and/or/not" do
+      pred = Confium::Attributes.parse(
+        %q{and(min_count("role:director", 3), min_distinct("region", 3))}
+      )
+      expect(pred.satisfied_by?([alice, bob, carol])).to be(true)
+
+      pred_or = Confium::Attributes.parse(
+        %q{or(min_count("role:director", 5), any("region"))}
+      )
+      expect(pred_or.satisfied_by?([alice])).to be(true)
+
+      pred_not = Confium::Attributes.parse(
+        %q{not(any("nationality:cn"))}
+      )
+      expect(pred_not.satisfied_by?([alice, bob])).to be(true)
+    end
+  end
+end

--- a/spec/confium/composite_spec.rb
+++ b/spec/confium/composite_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "confium"
+
+RSpec.describe Confium::Composite do
+  describe ".generate_ed25519_keypair" do
+    it "returns a 32-byte private key and a 32-byte public key" do
+      kp = described_class.generate_ed25519_keypair
+      expect(kp["private_key"].bytesize).to eq(32)
+      expect(kp["public_key"].bytesize).to eq(32)
+    end
+
+    it "produces a fresh keypair each call" do
+      kp1 = described_class.generate_ed25519_keypair
+      kp2 = described_class.generate_ed25519_keypair
+      expect(kp1["private_key"]).not_to eq(kp2["private_key"])
+    end
+  end
+
+  describe ".sign_ed25519" do
+    let(:kp) { described_class.generate_ed25519_keypair }
+
+    it "builds an Ed25519 component signature" do
+      comp = described_class.sign_ed25519(kp["private_key"], "hello")
+      expect(comp["algorithm"]).to eq("Ed25519")
+      expect(comp["public_key"].bytesize).to eq(32)
+      expect(comp["signature"].bytesize).to eq(64)
+      expect(comp["public_key"]).to eq(kp["public_key"])
+    end
+
+    it "rejects private keys that are not 32 bytes" do
+      expect {
+        described_class.sign_ed25519(("x" * 16), "hello")
+      }.to raise_error(ArgumentError, /Ed25519 private key must be 32 bytes/)
+    end
+  end
+
+  describe "Confium::Composite::Signature" do
+    let(:kp) { described_class.generate_ed25519_keypair }
+    let(:component) { described_class.sign_ed25519(kp["private_key"], "msg") }
+
+    it "exposes component_count and algorithms" do
+      sig = described_class::Signature.new([component])
+      expect(sig.component_count).to eq(1)
+      expect(sig.algorithms).to eq(["Ed25519"])
+    end
+
+    it "verifies a real Ed25519 signature for the right message" do
+      sig = described_class::Signature.new([component])
+      result = sig.verify("msg")
+      expect(result).to be_a(described_class::VerificationResult)
+      expect(result.all_verified?).to be(true)
+    end
+
+    it "fails verification for the wrong message" do
+      sig = described_class::Signature.new([component])
+      result = sig.verify("wrong")
+      expect(result.all_verified?).to be(false)
+      details = result.per_component
+      expect(details.size).to eq(1)
+      expect(details[0]["verified"]).to be(false)
+      expect(details[0]["error"]).to be_a(String)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds two more high-level subsystems to the Rust native extension (Phase 1B), continuing the parsanol-ruby-pattern work started in #13:

- **`Confium::Composite`** — PQ-migration composite signatures (Ed25519 + future ML-DSA-65). Wraps `confium_composite` directly. Includes a `generate_ed25519_keypair` helper and the `Signature#verify(message)` -> `VerificationResult` round trip.
- **`Confium::Attributes`** — attribute-based threshold-signing policy DSL. Wraps `confium_attributes::{Predicate, SignerAttributes, evaluate, parse}`. DSL covers `min_count`, `min_distinct`, `any`, `all`, `none`, with `and`/`or`/`not` composition.

Both follow the same byte-shape conventions as Phase 1A: binary `String` inputs/outputs (`Encoding::ASCII_8BIT`), `RArray::try_convert` + `each()` for collection conversion to satisfy magnus 0.8's `TryConvertOwned` bound.

## Test plan

- [x] `bundle exec rake compile` — clean build
- [x] `bundle exec rspec` — **27 specs pass total**:
  - Phase 1A (transparency): 10
  - Phase 1B (composite): 10
  - Phase 1B (attributes): 7

## Smoke

```ruby
kp = Confium::Composite.generate_ed25519_keypair
comp = Confium::Composite.sign_ed25519(kp["private_key"], "hello")
Confium::Composite::Signature.new([comp]).verify("hello").all_verified?  # => true

pred = Confium::Attributes.parse(%q{and(min_count("role:director", 3), min_distinct("region", 3))})
pred.satisfied_by?([alice, bob, carol])  # => true if each is a director from a distinct region
```

## Next

- **Phase 1C**: `Confium::Cert`, `Confium::CMS`, `Confium::TC::Session`, `Confium::Identity`, `Confium::Config`. Larger surface; probably two PRs.
- **Phase 2A**: `@confium/confium-wasm` crate (verifier-only, single tree-shakable package) — separate repo or sibling crate.
- **Phase 3**: docs cross-linking across Rust/Ruby/JS.
