### PR TITLE
feat(native-ext): Confium::Identity + Confium::Config — Phase 1C-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "confium-deployment"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885be74ce71dceef7c5ccfad937723b99b556fdf2d003d2ca774cf42d1d7e50e"
+dependencies = [
+ "chrono",
+ "data-encoding",
+ "serde",
+ "serde_json",
+ "snafu",
+ "thiserror",
+ "toml",
+ "url",
+]
+
+[[package]]
 name = "confium-pki"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +269,7 @@ dependencies = [
  "confium-attributes",
  "confium-composite",
  "confium-core",
+ "confium-deployment",
  "confium-pki",
  "confium-transparency",
  "ed25519-dalek",
@@ -372,6 +389,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +453,15 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -482,6 +525,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +558,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -576,6 +738,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -671,6 +839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +870,15 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -891,6 +1074,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +1138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "snafu"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1185,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1219,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1247,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1082,6 +1307,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1368,24 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "version_check"
@@ -1229,6 +1513,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "x509-cert"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,6 +1539,29 @@ dependencies = [
  "signature",
  "spki",
  "tls_codec",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -1263,6 +1585,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1619,39 @@ name = "zeroize_derive"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ext/confium_native/Cargo.toml
+++ b/ext/confium_native/Cargo.toml
@@ -30,6 +30,7 @@ confium-transparency = "0.3"
 confium-composite = "0.3"
 confium-attributes = "0.3"
 confium-pki = "0.3"
+confium-deployment = "0.3"
 
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }

--- a/ext/confium_native/src/deployment.rs
+++ b/ext/confium_native/src/deployment.rs
@@ -1,0 +1,173 @@
+//! Confium::Identity + Confium::Config — Ruby surface for the deployment
+//! crate's identity + manifest types.
+//!
+//! Phase 1C-2 scope:
+//!   - `Confium::Identity::Actor` — wraps `confium_deployment::identity::ActorIdentity`.
+//!   - `Confium::Identity::ACTOR_TYPES` — array of valid actor-type strings.
+//!   - `Confium::Config::Manifest` — parse + validate deployment manifest TOML.
+
+use confium_deployment::{
+    identity::{ActorIdentity, ActorType},
+    manifest::{parse_manifest, Manifest as RustManifest},
+    validate::validate_manifest,
+};
+use magnus::{exception, function, method, prelude::*, typed_data::Obj, DataTypeFunctions, Error, Module, Object, Ruby, TypedData};
+
+#[derive(TypedData, DataTypeFunctions)]
+#[magnus(class = "Confium::Identity::Actor", size)]
+pub struct Actor {
+    pub inner: std::cell::RefCell<ActorIdentity>,
+}
+
+impl Actor {
+    fn from_json(json: String) -> Result<Obj<Self>, Error> {
+        let actor: ActorIdentity = serde_json::from_str(&json)
+            .map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+        let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+        Ok(ruby.obj_wrap(Self {
+            inner: std::cell::RefCell::new(actor),
+        }))
+    }
+
+    fn to_json(&self) -> Result<String, Error> {
+        serde_json::to_string(&*self.inner.borrow())
+            .map_err(|e| Error::new(exception::runtime_error(), e.to_string()))
+    }
+
+    fn actor_id(&self) -> String {
+        self.inner.borrow().actor_id.clone()
+    }
+
+    fn actor_type(&self) -> String {
+        actor_type_str(self.inner.borrow().actor_type).to_string()
+    }
+
+    fn quorum_id(&self) -> Option<String> {
+        self.inner.borrow().quorum_id.clone()
+    }
+
+    fn registered_at_iso8601(&self) -> String {
+        self.inner.borrow().registered_at.to_rfc3339()
+    }
+
+    fn expires_at_iso8601(&self) -> Option<String> {
+        self.inner.borrow().expires_at.map(|t| t.to_rfc3339())
+    }
+
+    fn certificate_count(&self) -> usize {
+        self.inner.borrow().certificate_chain_der.len()
+    }
+}
+
+fn actor_type_str(t: ActorType) -> &'static str {
+    match t {
+        ActorType::Manufacturer => "manufacturer",
+        ActorType::TestingLab => "testing_lab",
+        ActorType::IssuingAuthorityOfficer => "issuing_authority_officer",
+        ActorType::BimlDirector => "biml_director",
+        ActorType::QuorumCoordinator => "quorum_coordinator",
+        ActorType::Verifier => "verifier",
+    }
+}
+
+fn actor_types() -> Vec<&'static str> {
+    vec![
+        actor_type_str(ActorType::Manufacturer),
+        actor_type_str(ActorType::TestingLab),
+        actor_type_str(ActorType::IssuingAuthorityOfficer),
+        actor_type_str(ActorType::BimlDirector),
+        actor_type_str(ActorType::QuorumCoordinator),
+        actor_type_str(ActorType::Verifier),
+    ]
+}
+
+#[derive(TypedData, DataTypeFunctions)]
+#[magnus(class = "Confium::Config::Manifest", size)]
+pub struct Manifest {
+    pub inner: std::cell::RefCell<RustManifest>,
+}
+
+impl Manifest {
+    fn from_toml(toml_str: String) -> Result<Obj<Self>, Error> {
+        let manifest = parse_manifest(&toml_str)
+            .map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+        let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+        Ok(ruby.obj_wrap(Self {
+            inner: std::cell::RefCell::new(manifest),
+        }))
+    }
+
+    fn deployment_name(&self) -> String {
+        self.inner.borrow().deployment.name.clone()
+    }
+
+    fn operator(&self) -> String {
+        self.inner.borrow().deployment.operator.clone()
+    }
+
+    fn manifest_version(&self) -> u32 {
+        self.inner.borrow().deployment.manifest_version
+    }
+
+    fn tier_count(&self) -> usize {
+        self.inner.borrow().tiers.len()
+    }
+
+    fn tier_name_at(&self, index: usize) -> Result<String, Error> {
+        self.inner
+            .borrow()
+            .tiers
+            .get(index)
+            .map(|t| t.name.clone())
+            .ok_or_else(|| {
+                Error::new(
+                    exception::index_error(),
+                    format!("tier index {index} out of range"),
+                )
+            })
+    }
+
+    fn quorum_count(&self) -> usize {
+        self.inner.borrow().quorums.len()
+    }
+
+    fn validate(&self) -> Result<Vec<String>, Error> {
+        let m = self.inner.borrow();
+        let report = validate_manifest(&m);
+        Ok(report.errors)
+    }
+
+    fn is_valid(&self) -> Result<bool, Error> {
+        let m = self.inner.borrow();
+        let report = validate_manifest(&m);
+        Ok(report.errors.is_empty())
+    }
+}
+
+pub fn init(ruby: &Ruby, parent: magnus::RModule) -> Result<(), Error> {
+    let identity = parent.define_module("Identity")?;
+    identity.define_module_function("actor_types", function!(actor_types, 0))?;
+    let actor_class = identity.define_class("Actor", ruby.class_object())?;
+    actor_class.define_singleton_method("from_json", function!(Actor::from_json, 1))?;
+    actor_class.define_method("to_json", method!(Actor::to_json, 0))?;
+    actor_class.define_method("actor_id", method!(Actor::actor_id, 0))?;
+    actor_class.define_method("actor_type", method!(Actor::actor_type, 0))?;
+    actor_class.define_method("quorum_id", method!(Actor::quorum_id, 0))?;
+    actor_class.define_method("registered_at", method!(Actor::registered_at_iso8601, 0))?;
+    actor_class.define_method("expires_at", method!(Actor::expires_at_iso8601, 0))?;
+    actor_class.define_method("certificate_count", method!(Actor::certificate_count, 0))?;
+
+    let config = parent.define_module("Config")?;
+    let manifest_class = config.define_class("Manifest", ruby.class_object())?;
+    manifest_class.define_singleton_method("from_toml", function!(Manifest::from_toml, 1))?;
+    manifest_class.define_method("deployment_name", method!(Manifest::deployment_name, 0))?;
+    manifest_class.define_method("operator", method!(Manifest::operator, 0))?;
+    manifest_class.define_method("manifest_version", method!(Manifest::manifest_version, 0))?;
+    manifest_class.define_method("tier_count", method!(Manifest::tier_count, 0))?;
+    manifest_class.define_method("tier_name_at", method!(Manifest::tier_name_at, 1))?;
+    manifest_class.define_method("quorum_count", method!(Manifest::quorum_count, 0))?;
+    manifest_class.define_method("validate", method!(Manifest::validate, 0))?;
+    manifest_class.define_method("valid?", method!(Manifest::is_valid, 0))?;
+
+    Ok(())
+}

--- a/ext/confium_native/src/lib.rs
+++ b/ext/confium_native/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod attributes;
 mod composite;
+mod deployment;
 mod pki;
 mod transparency;
 
@@ -39,5 +40,6 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     composite::init(ruby, confium)?;
     attributes::init(ruby, confium)?;
     pki::init(ruby, confium)?;
+    deployment::init(ruby, confium)?;
     Ok(())
 }

--- a/spec/confium/deployment_spec.rb
+++ b/spec/confium/deployment_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "confium"
+
+RSpec.describe Confium::Identity do
+  describe ".actor_types" do
+    it "returns the six canonical actor types" do
+      types = described_class.actor_types
+      expect(types).to eq(%w[
+        manufacturer
+        testing_lab
+        issuing_authority_officer
+        biml_director
+        quorum_coordinator
+        verifier
+      ])
+    end
+  end
+end
+
+RSpec.describe Confium::Identity::Actor do
+  let(:actor_json) do
+    %q|{
+      "actor_id": "biml-director-alice",
+      "actor_type": "biml_director",
+      "quorum_id": "biml-quorum",
+      "signing_key": {"kind":"software","key_id":"alice-signing","algorithm":"Ed25519"},
+      "certificate_chain_der": [],
+      "attributes": {"expertise":[],"role":[],"custom":{}},
+      "registered_at": "2026-07-27T00:00:00Z"
+    }|
+  end
+
+  describe ".from_json" do
+    it "parses a complete actor identity" do
+      actor = described_class.from_json(actor_json)
+      expect(actor).to be_a(described_class)
+      expect(actor.actor_id).to eq("biml-director-alice")
+      expect(actor.actor_type).to eq("biml_director")
+      expect(actor.quorum_id).to eq("biml-quorum")
+    end
+
+    it "raises on malformed JSON" do
+      expect { described_class.from_json("{not json") }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe "#to_json" do
+    it "round-trips through from_json" do
+      actor = described_class.from_json(actor_json)
+      round = described_class.from_json(actor.to_json)
+      expect(round.actor_id).to eq(actor.actor_id)
+      expect(round.actor_type).to eq(actor.actor_type)
+    end
+  end
+
+  describe "#registered_at" do
+    it "returns an ISO8601 timestamp" do
+      actor = described_class.from_json(actor_json)
+      expect(actor.registered_at).to match(/\A\d{4}-\d{2}-\d{2}T/)
+    end
+  end
+
+  describe "#expires_at" do
+    it "returns nil when no expiry is set" do
+      actor = described_class.from_json(actor_json)
+      expect(actor.expires_at).to be_nil
+    end
+
+    it "returns an ISO8601 timestamp when expiry is set" do
+      json = actor_json.sub(
+        %q|"registered_at": "2026-07-27T00:00:00Z"|,
+        %q|"registered_at": "2026-07-27T00:00:00Z", "expires_at": "2030-01-01T00:00:00Z"|
+      )
+      actor = described_class.from_json(json)
+      expect(actor.expires_at).to match(/\A2030-/)
+    end
+  end
+
+  describe "#certificate_count" do
+    it "returns the chain length" do
+      actor = described_class.from_json(actor_json)
+      expect(actor.certificate_count).to eq(0)
+    end
+  end
+end
+
+RSpec.describe Confium::Config::Manifest do
+  let(:manifest_toml) do
+    <<~TOML
+      [deployment]
+      name = "Test Deployment"
+      operator = "Ribose"
+      manifest_version = 1
+
+      [[tiers]]
+      name = "Manufacturer"
+      role = "manufacturer"
+      signing_algorithm = "Ed25519"
+      threshold = { t = 3, n = 5 }
+
+      [[tiers]]
+      name = "BIML"
+      role = "biml_director"
+      signing_algorithm = "Ed25519"
+      threshold = { t = 5, n = 9 }
+
+      [[quorums]]
+      name = "Manufacturers"
+      coordinator = "coord-001"
+      threshold = { t = 3, n = 5 }
+    TOML
+  end
+
+  describe ".from_toml" do
+    it "parses a complete manifest" do
+      m = described_class.from_toml(manifest_toml)
+      expect(m).to be_a(described_class)
+      expect(m.deployment_name).to eq("Test Deployment")
+      expect(m.operator).to eq("Ribose")
+      expect(m.manifest_version).to eq(1)
+    end
+
+    it "raises on malformed TOML" do
+      expect { described_class.from_toml("not = = toml") }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe "#tier_count / #tier_name_at" do
+    it "iterates the tiers in declaration order" do
+      m = described_class.from_toml(manifest_toml)
+      expect(m.tier_count).to eq(2)
+      expect(m.tier_name_at(0)).to eq("Manufacturer")
+      expect(m.tier_name_at(1)).to eq("BIML")
+    end
+
+    it "raises IndexError for out-of-range tier index" do
+      m = described_class.from_toml(manifest_toml)
+      expect { m.tier_name_at(99) }.to raise_error(IndexError, /out of range/)
+    end
+  end
+
+  describe "#quorum_count" do
+    it "returns the number of quorum definitions" do
+      m = described_class.from_toml(manifest_toml)
+      expect(m.quorum_count).to eq(1)
+    end
+  end
+
+  describe "#valid? / #validate" do
+    it "returns true and empty errors for a well-formed manifest" do
+      m = described_class.from_toml(manifest_toml)
+      expect(m.valid?).to be(true)
+      expect(m.validate).to eq([])
+    end
+
+    it "flags an unsupported manifest version" do
+      bad = manifest_toml.sub("manifest_version = 1", "manifest_version = 99")
+      m = described_class.from_toml(bad)
+      expect(m.valid?).to be(false)
+      expect(m.validate).to include(/unsupported manifest version/)
+    end
+  end
+end


### PR DESCRIPTION
Phase 1C-2: deployment surface.

- `Confium::Identity::Actor` wraps `confium_deployment::identity::ActorIdentity` — parse + field accessors + JSON round-trip.
- `Confium::Identity.actor_types` returns the six canonical actor role strings.
- `Confium::Config::Manifest` wraps `confium_deployment::manifest::Manifest` — TOML parse + deployment/tier/quorum accessors + validate / valid?.

## Test plan
- [x] `bundle exec rake compile` — clean build
- [x] `bundle exec rspec` — **61 specs total pass** (15 new)

## Next
Phase 1D: TC subsystem (FROST, CMP20, GG18, ElGamal, Coordinator, Reshare).