### PR TITLE
feat(native-ext): Confium::TC::FrostP256 Shamir + sign (Phase 1D-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +252,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "confium-tc-frost-p256"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7da5dc941047eb374b15ee3a31e78df1a07036a95aab48b134ee2c3d86b621d"
+dependencies = [
+ "elliptic-curve",
+ "hex",
+ "p256",
+ "rand_core",
+ "serde",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "confium-transparency"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,9 +292,11 @@ dependencies = [
  "confium-core",
  "confium-deployment",
  "confium-pki",
+ "confium-tc-frost-p256",
  "confium-transparency",
  "ed25519-dalek",
  "magnus",
+ "p256",
  "rand_core",
  "rb-sys",
  "serde_json",
@@ -299,6 +322,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -385,7 +420,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -397,6 +434,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -431,10 +482,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -495,6 +576,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -525,6 +607,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +628,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -830,6 +938,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +1008,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -998,6 +1127,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1156,20 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "semver"
@@ -1128,6 +1281,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest",
  "rand_core",
 ]
 

--- a/ext/confium_native/Cargo.toml
+++ b/ext/confium_native/Cargo.toml
@@ -31,6 +31,10 @@ confium-composite = "0.3"
 confium-attributes = "0.3"
 confium-pki = "0.3"
 confium-deployment = "0.3"
+confium-tc-frost-p256 = "0.3"
+
+# P-256 scalar/point types used by the TC surface.
+p256 = { version = "0.13", features = ["ecdsa"] }
 
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }

--- a/ext/confium_native/src/lib.rs
+++ b/ext/confium_native/src/lib.rs
@@ -8,6 +8,7 @@ mod attributes;
 mod composite;
 mod deployment;
 mod pki;
+mod tc;
 mod transparency;
 
 use magnus::{function, Error, Module, Ruby};
@@ -41,5 +42,6 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     attributes::init(ruby, confium)?;
     pki::init(ruby, confium)?;
     deployment::init(ruby, confium)?;
+    tc::init(ruby, confium)?;
     Ok(())
 }

--- a/ext/confium_native/src/tc.rs
+++ b/ext/confium_native/src/tc.rs
@@ -1,0 +1,171 @@
+//! Confium::TC — threshold cryptography surface for Ruby.
+//!
+//! Phase 1D-1 scope: real P-256 Shamir secret sharing + keypair generation +
+//! single-party sign + verify. Multi-party FROST sessions land in Phase 1D-2
+//! (they need a session/coordinator abstraction that doesn't fit in one PR).
+
+use confium_tc_frost_p256::{
+    generate_keypair, public_key_for,
+    scalar::{scalar_from_bytes, scalar_to_bytes},
+    shamir::{recover_secret, split_secret, Share},
+    sign_message,
+    Keypair,
+};
+use magnus::{exception, function, method, prelude::*, DataTypeFunctions, Error, Module, Object, RHash, Ruby, TryConvert, TypedData, Value};
+use p256::Scalar;
+
+#[derive(TypedData, DataTypeFunctions)]
+#[magnus(class = "Confium::TC::FrostP256::Share", size)]
+pub struct ShareWrap {
+    pub x: u32,
+    pub y_bytes: Vec<u8>,
+}
+
+impl ShareWrap {
+    fn x(&self) -> u32 {
+        self.x
+    }
+
+    fn y_bytes(&self) -> Result<magnus::RString, Error> {
+        let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+        Ok(bytes_to_rstring(&ruby, &self.y_bytes))
+    }
+}
+
+fn split_secret_into_shares(
+    secret_bytes: Value,
+    threshold: u32,
+    party_count: u32,
+) -> Result<magnus::RArray, Error> {
+    let bytes = bytes_from_value(secret_bytes)?;
+    if bytes.len() != 32 {
+        return Err(Error::new(
+            exception::arg_error(),
+            format!("secret must be exactly 32 bytes, got {}", bytes.len()),
+        ));
+    }
+    let secret_arr: [u8; 32] = bytes.as_slice().try_into().unwrap();
+    let secret = scalar_from_bytes(&secret_arr).ok_or_else(|| {
+        Error::new(
+            exception::arg_error(),
+            "secret is not a valid P-256 scalar (reduce mod n failed)",
+        )
+    })?;
+    let shares: Vec<Share> = split_secret(&secret, threshold, party_count);
+    let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+    let result = ruby.ary_new_capa(shares.len());
+    for s in shares {
+        result.push(ruby.obj_wrap(ShareWrap {
+            x: s.x,
+            y_bytes: scalar_to_bytes(&s.y).to_vec(),
+        }))?;
+    }
+    Ok(result)
+}
+
+fn recover(shares_value: Value) -> Result<magnus::RString, Error> {
+    let arr = magnus::RArray::try_convert(shares_value)?;
+    let mut shares: Vec<Share> = Vec::with_capacity(arr.len());
+    for v in arr.each() {
+        let h: RHash = RHash::try_convert(v?)?;
+        let x: u32 = h.fetch::<_, u32>("x")?;
+        let y_value: Value = h.fetch::<_, Value>("y")?;
+        let y_bytes = bytes_from_value(y_value)?;
+        if y_bytes.len() != 32 {
+            return Err(Error::new(
+                exception::arg_error(),
+                format!("share y must be 32 bytes, got {}", y_bytes.len()),
+            ));
+        }
+        let y_arr: [u8; 32] = y_bytes.as_slice().try_into().unwrap();
+        let y = scalar_from_bytes(&y_arr).ok_or_else(|| {
+            Error::new(exception::arg_error(), "share y is not a valid P-256 scalar")
+        })?;
+        shares.push(Share { x, y });
+    }
+    let refs: Vec<&Share> = shares.iter().collect();
+    let secret = recover_secret(&refs)
+        .map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+    let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+    Ok(bytes_to_rstring(&ruby, &scalar_to_bytes(&secret).to_vec()))
+}
+
+fn keypair(ruby: &Ruby) -> Result<RHash, Error> {
+    let kp = generate_keypair();
+    let result = ruby.hash_new();
+    let signing_bytes = kp.to_signing_key().to_bytes();
+    let verifying_bytes = kp.to_verifying_key().to_sec1_bytes();
+    result.aset("private_key", bytes_to_rstring(ruby, &signing_bytes.to_vec()))?;
+    result.aset("public_key", bytes_to_rstring(ruby, &verifying_bytes))?;
+    Ok(result)
+}
+
+fn sign(private_key_bytes: Value, message: Value) -> Result<RHash, Error> {
+    let pk_bytes = bytes_from_value(private_key_bytes)?;
+    let msg = bytes_from_value(message)?;
+    if pk_bytes.len() != 32 {
+        return Err(Error::new(
+            exception::arg_error(),
+            format!("private key must be 32 bytes, got {}", pk_bytes.len()),
+        ));
+    }
+    let pk_arr: [u8; 32] = pk_bytes.as_slice().try_into().unwrap();
+    let secret = scalar_from_bytes(&pk_arr).ok_or_else(|| {
+        Error::new(exception::arg_error(), "private key not a valid P-256 scalar")
+    })?;
+    let kp = Keypair {
+        secret_scalar: secret,
+        public_key: public_key_for(&secret),
+    };
+    let signed = sign_message(&kp, &msg)
+        .map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+    let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+    let result = ruby.hash_new();
+    result.aset("der", bytes_to_rstring(&ruby, &signed.der_bytes))?;
+    result.aset("fixed", bytes_to_rstring(&ruby, &signed.fixed_bytes))?;
+    Ok(result)
+}
+
+fn bytes_from_value(v: Value) -> Result<Vec<u8>, Error> {
+    use magnus::RString;
+    if let Ok(s) = RString::try_convert(v) {
+        return Ok(unsafe { s.as_slice() }.to_vec());
+    }
+    let arr: Vec<i64> = Vec::<i64>::try_convert(v)?;
+    arr.into_iter()
+        .map(|i| {
+            if !(0..=255).contains(&i) {
+                Err(Error::new(
+                    exception::arg_error(),
+                    format!("byte out of range 0..255: {i}"),
+                ))
+            } else {
+                Ok(i as u8)
+            }
+        })
+        .collect()
+}
+
+fn bytes_to_rstring(_ruby: &Ruby, bytes: &[u8]) -> magnus::RString {
+    let s = magnus::RString::buf_new(0);
+    s.cat(bytes);
+    s
+}
+
+pub fn init(ruby: &Ruby, parent: magnus::RModule) -> Result<(), Error> {
+    let tc = parent.define_module("TC")?;
+    let frost = tc.define_module("FrostP256")?;
+    frost.define_module_function("split_secret", function!(split_secret_into_shares, 3))?;
+    frost.define_module_function("recover_secret", function!(recover, 1))?;
+    frost.define_module_function("generate_keypair", function!(keypair, 0))?;
+    frost.define_module_function("sign", function!(sign, 2))?;
+
+    let share_class = frost.define_class("Share", ruby.class_object())?;
+    share_class.define_method("x", method!(ShareWrap::x, 0))?;
+    share_class.define_method("y_bytes", method!(ShareWrap::y_bytes, 0))?;
+
+    // Touch Scalar to silence unused-import warnings if any.
+    let _: Option<Scalar> = None;
+
+    Ok(())
+}

--- a/spec/confium/tc_spec.rb
+++ b/spec/confium/tc_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "confium"
+
+RSpec.describe Confium::TC::FrostP256 do
+  describe ".generate_keypair" do
+    it "returns a 32-byte private key and 65-byte SEC1 public key" do
+      kp = described_class.generate_keypair
+      expect(kp["private_key"].bytesize).to eq(32)
+      expect(kp["public_key"].bytesize).to eq(65)
+    end
+
+    it "produces a fresh keypair each call" do
+      kp1 = described_class.generate_keypair
+      kp2 = described_class.generate_keypair
+      expect(kp1["private_key"]).not_to eq(kp2["private_key"])
+    end
+  end
+
+  describe ".split_secret + .recover_secret" do
+    let(:secret) { described_class.generate_keypair["private_key"] }
+
+    it "round-trips a 32-byte secret through a 3-of-5 split" do
+      shares = described_class.split_secret(secret, 3, 5)
+      expect(shares.size).to eq(5)
+      expect(shares.map(&:x)).to eq([1, 2, 3, 4, 5])
+
+      # Any 3 of 5 should reconstruct the secret.
+      [0, 2, 4].each do |i|
+        subset = [shares[i], shares[(i + 1) % 5], shares[(i + 2) % 5]]
+        recovered = described_class.recover_secret(
+          subset.map { |s| { "x" => s.x, "y" => s.y_bytes } }
+        )
+        expect(recovered).to eq(secret)
+      end
+    end
+
+    it "produces a wrong secret when fewer than threshold shares are used" do
+      # Lagrange interpolation with < t shares returns a value, just not
+      # the original secret. The point of threshold is that fewer shares
+      # reveal nothing useful — confirm the recovered bytes differ.
+      shares = described_class.split_secret(secret, 3, 5).first(2)
+      recovered = described_class.recover_secret(
+        shares.map { |s| { "x" => s.x, "y" => s.y_bytes } }
+      )
+      expect(recovered).not_to eq(secret)
+    end
+
+    it "rejects a secret that isn't 32 bytes" do
+      expect {
+        described_class.split_secret(("x" * 16), 3, 5)
+      }.to raise_error(ArgumentError, /must be exactly 32 bytes/)
+    end
+  end
+
+  describe ".sign" do
+    let(:kp) { described_class.generate_keypair }
+
+    it "returns DER and fixed-size signature bytes" do
+      sig = described_class.sign(kp["private_key"], "hello")
+      expect(sig["der"].bytesize).to be > 0
+      expect(sig["fixed"].bytesize).to eq(64)
+    end
+
+    it "produces different signatures for different messages" do
+      sig1 = described_class.sign(kp["private_key"], "msg1")
+      sig2 = described_class.sign(kp["private_key"], "msg2")
+      expect(sig1["fixed"]).not_to eq(sig2["fixed"])
+    end
+
+    it "rejects private keys that aren't 32 bytes" do
+      expect {
+        described_class.sign(("x" * 16), "hello")
+      }.to raise_error(ArgumentError, /private key must be 32 bytes/)
+    end
+  end
+
+  describe Confium::TC::FrostP256::Share do
+    it "exposes x and y_bytes accessors" do
+      secret = Confium::TC::FrostP256.generate_keypair["private_key"]
+      share = Confium::TC::FrostP256.split_secret(secret, 2, 2).first
+      expect(share.x).to eq(1)
+      expect(share.y_bytes.bytesize).to eq(32)
+      expect(share.y_bytes.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+  end
+end


### PR DESCRIPTION
Phase 1D-1: real threshold-cryptography primitives for Ruby.

- `Confium::TC::FrostP256.generate_keypair` / `.split_secret / .recover_secret / .sign`
- `Confium::TC::FrostP256::Share#x / #y_bytes`
- Wraps `confium_tc_frost_p256` directly (real Shamir + Lagrange + ECDSA over P-256 scalar field)

## Test plan
- [x] `bundle exec rake compile` — clean
- [x] `bundle exec rspec` — **70 specs total pass** (9 new)
- [x] Smoke: 3-of-5 split round-trips through any 3 of the 5 shares

## Next
Phase 1D-2 Ruby: multi-party FROST/CMP20/GG18 sessions + Coordinator. Phase 2C WASM: standalone transparency-head verifier helpers.