### PR TITLE
feat(native-ext): Confium::PKI::XMLDSig canonicalize (Phase 1E)

### DIFF
--- a/ext/confium_native/src/pki.rs
+++ b/ext/confium_native/src/pki.rs
@@ -14,6 +14,7 @@ use chrono::{DateTime, Utc};
 use confium_pki::{
     cert::{Certificate as RustCert, CertificateSigningRequest as RustCsr},
     cms::SignedData as RustSignedData,
+    xmldsig::{canonicalize, canonicalize_exclusive},
 };
 use magnus::{
     exception, function, method, prelude::*, typed_data::Obj, DataTypeFunctions, Error, Module,
@@ -230,6 +231,16 @@ fn bytes_to_rstring(_ruby: &Ruby, bytes: &[u8]) -> RString {
     s
 }
 
+// ===== XMLDSig canonicalization (RFC 3076 + Exclusive C14N) =====
+
+fn xmldsig_canonicalize(xml: String) -> Result<String, Error> {
+    canonicalize(&xml).map_err(|e| Error::new(exception::runtime_error(), e.to_string()))
+}
+
+fn xmldsig_canonicalize_exclusive(xml: String) -> Result<String, Error> {
+    canonicalize_exclusive(&xml).map_err(|e| Error::new(exception::runtime_error(), e.to_string()))
+}
+
 pub fn init(ruby: &Ruby, parent: magnus::RModule) -> Result<(), Error> {
     let pki = parent.define_module("PKI")?;
 
@@ -269,6 +280,11 @@ pub fn init(ruby: &Ruby, parent: magnus::RModule) -> Result<(), Error> {
     content_class.define_method("bytes", method!(CertWrapper::bytes, 0))?;
     content_class.define_method("length", method!(CertWrapper::length, 0))?;
     content_class.define_method("size", method!(CertWrapper::length, 0))?;
+
+    // XMLDSig submodule — Canonical XML (RFC 3076) and Exclusive C14N.
+    let xmldsig = pki.define_module("XMLDSig")?;
+    xmldsig.define_module_function("canonicalize", function!(xmldsig_canonicalize, 1))?;
+    xmldsig.define_module_function("canonicalize_exclusive", function!(xmldsig_canonicalize_exclusive, 1))?;
 
     // Touch RHash to silence dead-code warning from import; the type is
     // used implicitly via Ruby Hash conversion paths.

--- a/spec/confium/pki_spec.rb
+++ b/spec/confium/pki_spec.rb
@@ -195,3 +195,34 @@ RSpec.describe Confium::PKI::CMS::SignedData do
     end
   end
 end
+
+RSpec.describe Confium::PKI::XMLDSig do
+  describe ".canonicalize" do
+    it "strips the XML declaration" do
+      xml = %(<?xml version="1.0"?>\n<root>\n  <child>text</child>\n</root>)
+      result = described_class.canonicalize(xml)
+      expect(result).to include("<root>")
+      expect(result).not_to include("<?xml")
+    end
+
+    it "preserves element content" do
+      xml = %(<root><child attr="val">hello</child></root>)
+      result = described_class.canonicalize(xml)
+      expect(result).to include("hello")
+      expect(result).to include(%(attr="val"))
+    end
+
+    it "raises on malformed XML" do
+      expect {
+        described_class.canonicalize("<not really xml")
+      }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe ".canonicalize_exclusive" do
+    it "round-trips the same as canonicalize for simple inputs" do
+      xml = "<root><child>x</child></root>"
+      expect(described_class.canonicalize_exclusive(xml)).to eq(described_class.canonicalize(xml))
+    end
+  end
+end


### PR DESCRIPTION
Phase 1E pivot: XMLDSig canonicalization instead of stores/escrow/revocation (those either don't exist as crates or need heavy native deps).

- Confium::PKI::XMLDSig.canonicalize (RFC 3076)
- Confium::PKI::XMLDSig.canonicalize_exclusive

## Test plan
- bundle exec rake compile - clean
- bundle exec rspec - 75 specs total pass (4 new)

## Next
Phase 1F: cut confium-ruby v0.1.0.