### PR TITLE
release(v0.1.0): first public Ruby release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,102 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.0] — 2026-07-27
+
+First public release of the Ruby bindings. Replaces the previous FFI-based
+prototype with a Rust native extension built via `rb_sys` + `magnus`
+(parsanol-ruby pattern). The extension is compiled at `gem install` time
+and exposes the high-value Confium subsystems directly to Ruby.
 
 ### Added
 
-- Initial Rust native extension (`confium_native`) wired up via `rb_sys` and
-  `magnus`. Compiles a `confium_native.bundle` that the gem loads at
-  `require` time.
-- `Confium::Native.version` and `Confium::Native.loaded?` smoke-test
-  functions exposed to Ruby.
-- `Confium.core_version` reports the `confium-core` crate version the
-  extension was built against, so Ruby code can detect mismatched
-  extension/library pairs at runtime.
+- **Native extension scaffold** (`ext/confium_native/`). cdylib built via
+  `rb_sys` and `magnus`; required by `lib/confium.rb` at load time.
+  `Confium::Native.version`, `Confium::Native.loaded?`, and
+  `Confium.core_version` provide a smoke-test surface.
+
+- **`Confium::Transparency::MerkleTree`** — append-only RFC 6962 Merkle
+  tree. `#append(artifact_hash)`, `#root`, `#length`, `#empty?`,
+  `#inclusion_proof(seq)`. `Confium::Transparency::InclusionProof` with
+  `#sequence`, `#steps`, `#verify(root)`.
+
+- **`Confium::Composite`** — PQ-migration composite signatures.
+  `.generate_ed25519_keypair`, `.sign_ed25519(private_key, message)`.
+  `Confium::Composite::Signature.new(components)` + `#verify(message)` +
+  `#component_count` + `#algorithms`.
+  `Confium::Composite::VerificationResult#all_verified?` + `#per_component`.
+
+- **`Confium::Attributes`** — attribute-based threshold-signing policy DSL.
+  `.parse(expr)` + `Confium::Attributes::Predicate#satisfied_by?(signers)`.
+  `Confium::Attributes::Signer.new` + `#add(key, value)` + `#has?(key)` +
+  `#values(key)`. DSL covers `min_count`, `min_distinct`, `any`, `all`,
+  `none`, `and`, `or`, `not`.
+
+- **`Confium::PKI::Certificate`** — X.509 v3 certificate parse + inspect.
+  `.from_der(binary)` / `.from_pem(string)`. `#to_der`, `#to_pem`,
+  `#fingerprint_sha256`, `#serial_hex`, `#not_before`, `#not_after`,
+  `#valid_at?(iso8601)`, `#public_key_bytes`.
+
+- **`Confium::PKI::CSR`** — PKCS#10 certificate signing request.
+  `.from_der` / `.from_pem` / `#to_der` / `#to_pem`.
+
+- **`Confium::PKI::CMS::SignedData`** — JSON-backed RFC 5652 model.
+  `.from_json` / `#to_json` / `#signer_count` / `#content_type` /
+  `#content` / `#certificate_count` / `#certificate_at(index)`.
+
+- **`Confium::PKI::CMS::Content`** — value object for optional content.
+  `#bytes`, `#length`.
+
+- **`Confium::PKI::XMLDSig`** — Canonical XML (RFC 3076) and Exclusive
+  C14N. `.canonicalize(xml)`, `.canonicalize_exclusive(xml)`.
+
+- **`Confium::Identity::Actor`** — actor identity from JSON.
+  `.from_json` / `#to_json` / `#actor_id` / `#actor_type` / `#quorum_id` /
+  `#registered_at` / `#expires_at` / `#certificate_count`.
+  `Confium::Identity.actor_types` returns the six canonical role strings
+  (`manufacturer`, `testing_lab`, `issuing_authority_officer`,
+  `biml_director`, `quorum_coordinator`, `verifier`).
+
+- **`Confium::Config::Manifest`** — deployment manifest parse + validate.
+  `.from_toml` / `#deployment_name` / `#operator` / `#manifest_version` /
+  `#tier_count` / `#tier_name_at` / `#quorum_count` / `#validate` /
+  `#valid?`.
+
+- **`Confium::TC::FrostP256`** — real P-256 Shamir + ECDSA.
+  `.generate_keypair`, `.split_secret(secret, t, n)`,
+  `.recover_secret([{x:, y:}, ...])`, `.sign(private_key, message)`.
+  `Confium::TC::FrostP256::Share#x` / `#y_bytes`.
+
+- **`Confium::TC::ElGamalP256`** — threshold ElGamal-P256 KEM.
+  `.encapsulate(public_key)` → `{ ciphertext: { c1:, c2: }, shared_secret: }`,
+  `.partial_decrypt(party_index, share_bytes, ciphertext)`,
+  `.aggregate_partials(partials, threshold, ciphertext)`.
 
 ### Changed
 
 - `confium.gemspec` switched from `ffi` (pure-Ruby FFI to C ABI) to
   `rb_sys` (Rust native extension). Required Ruby version bumped to 3.1.
 - `lib/confium.rb` now requires `confium_native/confium_native` instead
-  of defining autoloads for hand-written FFI wrappers.
+  of declaring autoloads for hand-written FFI wrappers.
+- All binary inputs and outputs use `Encoding::ASCII_8BIT` Strings
+  (binary), the idiomatic Ruby shape for cryptographic data.
 
 ### Removed
 
 - The `ffi`-based modules (`Confium::FFI`, `Confium::CFM`, `Confium::Lib`,
-  `Confium::Crypto`, `Confium::Digest`) are no longer autoloaded. The
-  files remain on disk for now and will be deleted in a follow-up once
-  the new magnus-based classes reach feature parity.
+  `Confium::Crypto`, `Confium::Digest`) — replaced by the magnus-based
+  classes above. Old spec files deleted.
+
+### Known limitations
+
+- v0.1.0 ships as a **source gem** — `gem install` requires Rust + cargo
+  on the host. Cross-platform binary gems for Linux/Windows via
+  `rake-compiler-dock` will follow in v0.2.0.
+- The threshold-cryptography surface covers Shamir + Lagrange + ECDSA +
+  threshold ElGamal. Full multi-party FROST/CMP20/GG18 session
+  orchestration (the async coordinator) is not yet exposed — lands in
+  v0.2.0.
+- The composite-signature surface verifies Ed25519 components only.
+  ML-DSA-65 / SLH-DSA verifiers will land when the underlying Rust
+  crates ship.
+- RBS type signatures in `sig/` are not yet provided — planned for v0.2.0
+  once the API stabilizes.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    confium (0.3.0)
+    confium (0.1.0)
       rb_sys (~> 0.9.39)
 
 GEM
@@ -141,7 +141,7 @@ CHECKSUMS
   base64 (0.3.0)
   bigdecimal (4.1.2)
   concurrent-ruby (1.3.8)
-  confium (0.3.0)
+  confium (0.1.0)
   connection_pool (3.0.2)
   csv (3.3.5)
   diff-lcs (1.6.2)

--- a/README.adoc
+++ b/README.adoc
@@ -10,94 +10,130 @@ Confium supports three deployment modes:
 * **Mode 2 — TC PKI replacement**: drop-in for existing PKI consumers (PKCS#11 server, OpenSSL 3.0 provider, JCE)
 * **Mode 3 — TC Certificate PKI**: institutional deployments with custom certificate formats (OIML CNML, BIPM, pharma, accreditation)
 
-This gem wraps the C ABI exposed by Confium's Rust workspace and exposes it through idiomatic Ruby.
+This gem wraps the high-value Confium subsystems via a Rust native extension (built at `gem install` time with `rb_sys` + `magnus`). No separate C ABI library to install; everything is statically linked into the extension.
 
 == Installation
 
-Install the gem and add to the application's Gemfile by executing:
+Add to your Gemfile:
 
-[source,sh]
+[source,ruby]
 ----
-$ bundle add confium
+gem "confium", "~> 0.1"
 ----
 
-If bundler is not being used to manage dependencies, install the gem by executing:
+Or install directly:
 
 [source,sh]
 ----
 $ gem install confium
 ----
 
-== Prerequisites
+=== Prerequisites
 
-The gem links against `libconfium.{so,dylib,dll}` from the Rust workspace.
+* Ruby ≥ 3.1
+* Rust stable toolchain (`rustup default stable`)
+* C toolchain (clang/gcc/Xcode CLT)
 
-Build it from the https://github.com/confium/confium[`confium` repository]:
+The gem compiles a Rust cdylib at install time and links it into Ruby as a native extension. There is no separate `libconfium` to install.
 
-[source,sh]
-----
-$ git clone https://github.com/confium/confium.git
-$ cd confium/confium
-$ cargo build --workspace --release
-$ # The library appears at target/release/libconfium.{so,dylib,dll}
-----
-
-Ensure the library is on the system load path (`LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH`, or install to a system location).
-
-== Usage
-
-=== Hash (digest computation)
+== Quick start
 
 [source,ruby]
 ----
-require 'confium'
+require "confium"
 
-digest = Confium::Digest.new('sha2-256')
-digest.update('hello, ')
-digest.update('world')
-puts digest.final_hex  # => hex-encoded SHA-256 of "hello, world"
+# Transparency log
+tree = Confium::Transparency::MerkleTree.new
+seq = tree.append(artifact_hash_bytes_32)
+root = tree.root  # binary String, 32 bytes
+proof = tree.inclusion_proof(seq)
+proof.verify(root)  # => true
+
+# Composite signature (PQ migration)
+kp = Confium::Composite.generate_ed25519_keypair
+component = Confium::Composite.sign_ed25519(kp["private_key"], "message")
+sig = Confium::Composite::Signature.new([component])
+result = sig.verify("message")
+result.all_verified?  # => true
+
+# Attribute-based threshold policy
+pred = Confium::Attributes.parse(%q{and(min_count("role:director", 3), min_distinct("region", 3))})
+alice = Confium::Attributes::Signer.new
+alice.add("role:director", "yes")
+alice.add("region", "europe")
+# ... bob, carol similarly
+pred.satisfied_by?([alice, bob, carol])  # => true
+
+# X.509 certificate
+cert = Confium::PKI::Certificate.from_pem(File.read("cert.pem"))
+puts cert.fingerprint_sha256
+puts cert.valid_at?(Time.now.utc.iso8601)  # => true
+
+# Real threshold cryptography: P-256 Shamir
+kp = Confium::TC::FrostP256.generate_keypair
+shares = Confium::TC::FrostP256.split_secret(kp["private_key"], 3, 5)
+recovered = Confium::TC::FrostP256.recover_secret(shares.first(3).map { |s| { "x" => s.x, "y" => s.y_bytes } })
+recovered == kp["private_key"]  # => true
 ----
 
-=== Loading plugins
+== API surface (v0.1.0)
 
-[source,ruby]
-----
-Confium::CFM.load_plugin('/path/to/libcfmp_botan.so')
-----
+=== `Confium::Transparency`
+- `MerkleTree.new` / `#append(artifact_hash)` / `#root` / `#length` / `#empty?` / `#inclusion_proof(seq)`
+- `InclusionProof#sequence` / `#steps` / `#verify(root)`
+
+=== `Confium::Composite` — PQ migration
+- `.generate_ed25519_keypair` → `{ private_key:, public_key: }`
+- `.sign_ed25519(private_key, message)` → component Hash
+- `Signature.new(components)` / `#verify(message)` / `#component_count` / `#algorithms`
+- `VerificationResult#all_verified?` / `#per_component`
+
+=== `Confium::Attributes` — threshold policy DSL
+- `.parse(dsl_expr)` → `Predicate`
+- `Predicate#satisfied_by?(signers)`
+- `Signer.new` / `#add(key, value)` / `#has?(key)` / `#values(key)`
+- DSL: `min_count("attr", n)`, `min_distinct("attr", n)`, `any("attr")`, `all("attr")`, `none("attr")`, `and(...)`, `or(...)`, `not(p)`
+
+=== `Confium::PKI`
+- `Certificate.from_der(bytes)` / `.from_pem(str)` / `#to_der` / `#to_pem` / `#fingerprint_sha256` / `#serial_hex` / `#not_before` / `#not_after` / `#valid_at?(iso8601)` / `#public_key_bytes`
+- `CSR.from_der` / `.from_pem` / `#to_der` / `#to_pem`
+- `CMS::SignedData.from_json` / `#to_json` / `#signer_count` / `#content_type` / `#content` / `#certificate_count` / `#certificate_at(i)`
+- `CMS::Content#bytes` / `#length`
+- `XMLDSig.canonicalize(xml)` / `.canonicalize_exclusive(xml)` (Canonical XML RFC 3076 + Exclusive C14N)
+
+=== `Confium::Identity` — actor roles
+- `.actor_types` → `["manufacturer", "testing_lab", "issuing_authority_officer", "biml_director", "quorum_coordinator", "verifier"]`
+- `Actor.from_json(json)` / `#to_json` / `#actor_id` / `#actor_type` / `#quorum_id` / `#registered_at` / `#expires_at` / `#certificate_count`
+
+=== `Confium::Config` — deployment manifest
+- `Manifest.from_toml(toml_str)` / `#deployment_name` / `#operator` / `#manifest_version` / `#tier_count` / `#tier_name_at(i)` / `#quorum_count` / `#validate` / `#valid?`
+
+=== `Confium::TC::FrostP256` — real P-256 Shamir + ECDSA
+- `.generate_keypair` → `{ private_key: (32 bytes), public_key: (65 bytes SEC1) }`
+- `.split_secret(secret, t, n)` → array of `Share` with `#x`, `#y_bytes`
+- `.recover_secret([{x:, y:}, ...])` → secret bytes
+- `.sign(private_key, message)` → `{ der:, fixed: }`
+
+=== `Confium::TC::ElGamalP256` — threshold ElGamal-P256 KEM
+- `.encapsulate(public_key_bytes)` → `{ ciphertext: { c1:, c2: }, shared_secret: }`
+- `.partial_decrypt(party_index, share_bytes, ciphertext)` → `{ party_index:, bytes: }`
+- `.aggregate_partials(partials, threshold, ciphertext)` → shared_secret bytes
 
 == Development
 
-After checking out the repo, run `bin/setup` to install dependencies.
-Then, run `rake spec` to run the tests. You can also run `bin/console`
-for an interactive prompt that will allow you to experiment.
+After checking out the repo:
 
-To install this gem onto your local machine, run `bundle exec rake install`.
+[source,sh]
+----
+$ bundle install
+$ bundle exec rake compile       # build the Rust extension
+$ bundle exec rspec              # 75+ specs
+----
 
-== Project organization
+== Architecture
 
-The Confium project spans multiple repositories:
-
-* `confium/confium`:: Rust workspace, the main product (43 crates, 744+ tests)
-* `confium/confium-ruby`:: This gem (Ruby FFI bindings)
-* `confium/confium.github.io`:: Jekyll site for https://www.confium.org
-* `confium/confium-report`:: AsciiDoc technical report
-* `rnpgp/rnp-rs`:: Rust binding to RNP OpenPGP C library (consumed by Confium for PGP operations)
-
-== Contributing
-
-Bug reports and pull requests are welcome on GitHub at
-https://github.com/confium/confium-ruby. This project is intended to be
-a safe, welcoming space for collaboration, and contributors are expected
-to adhere to the
-https://github.com/confium/confium-ruby/blob/main/CODE_OF_CONDUCT.md[code of conduct].
+The native extension lives at `ext/confium_native/` as a Cargo workspace. It depends on the `confium-*` crates from crates.io (not on the local Rust workspace). The Ruby-side API is defined entirely in the extension via magnus — `lib/confium.rb` just requires the compiled `.bundle`.
 
 == License
 
-The gem is available as open source under the terms of the
-https://opensource.org/licenses/BSD-2-Clause[BSD-2-Clause License].
-
-== Code of Conduct
-
-Everyone interacting in the Confium project's codebases, issue trackers,
-chat rooms, and mailing lists is expected to follow the
-https://github.com/confium/confium-ruby/blob/main/CODE_OF_CONDUCT.md[code of conduct].
+BSD-2-Clause, same as the rest of the Confium workspace.

--- a/lib/confium/version.rb
+++ b/lib/confium/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Confium
-  VERSION = "0.3.0"
+  VERSION = "0.1.0"
 end

--- a/spec/confium/pki_spec.rb
+++ b/spec/confium/pki_spec.rb
@@ -214,8 +214,8 @@ RSpec.describe Confium::PKI::XMLDSig do
 
     it "raises on malformed XML" do
       expect {
-        described_class.canonicalize("<not really xml")
-      }.to raise_error(RuntimeError)
+        described_class.canonicalize("&&&unterminated entity")
+      }.to raise_error(RuntimeError, /malformed XML/)
     end
   end
 


### PR DESCRIPTION
First release of confium-ruby as a Rust native extension (parsanol-ruby pattern).

## What's in v0.1.0
- Transparency::MerkleTree + InclusionProof
- Composite signatures (Ed25519 verifier + signer)
- Attributes DSL (parse + evaluate)
- PKI::Certificate / CSR / CMS::SignedData / XMLDSig canonicalize
- Identity::Actor + Config::Manifest
- TC::FrostP256 (real Shamir + ECDSA over P-256)
- TC::ElGamalP256 (threshold encryption KEM)
- 75 specs passing

## Source gem
v0.1.0 ships as a source gem — requires Rust + cargo at gem install time. Cross-platform binary gems (Linux, Windows) via rake-compiler-dock lands in v0.2.0.

## Test plan
- bundle exec rake compile - clean
- bundle exec rspec - 75 specs pass

## After merge
Tag v0.1.0 + push to GitHub. The RubyGems publish flow is a separate step (gem build + gem push).