### PR TITLE
feat(release): add rake-compiler-dock for cross-platform native gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,62 +131,63 @@ DEPENDENCIES
   confium!
   rake (~> 13.0)
   rake-compiler (~> 1.2.0)
+  rake-compiler-dock (~> 1.3)
   rspec (~> 3.0)
   rubocop (~> 1.21, ~> 1.0)
   steep (~> 1.5)
 
 CHECKSUMS
-  activesupport (8.1.3)
-  ast (2.4.3)
-  base64 (0.3.0)
-  bigdecimal (4.1.2)
-  concurrent-ruby (1.3.8)
+  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   confium (0.1.0)
-  connection_pool (3.0.2)
-  csv (3.3.5)
-  diff-lcs (1.6.2)
-  drb (2.2.3)
-  ffi (1.17.4)
-  ffi (1.17.4-arm64-darwin)
-  fileutils (1.8.0)
-  i18n (1.15.2)
-  json (2.21.1)
-  language_server-protocol (3.17.0.6)
-  lint_roller (1.1.0)
-  listen (3.10.0)
-  logger (1.7.0)
-  minitest (6.0.6)
-  mutex_m (0.3.0)
-  parallel (2.1.0)
-  parser (3.3.12.0)
-  prism (1.9.0)
-  racc (1.8.1)
-  rainbow (3.1.1)
-  rake (13.4.2)
-  rake-compiler (1.2.9)
-  rake-compiler-dock (1.11.0)
-  rb-fsevent (0.11.2)
-  rb-inotify (0.11.1)
-  rb_sys (0.9.126)
-  rbs (3.10.4)
-  regexp_parser (2.12.0)
-  rspec (3.13.2)
-  rspec-core (3.13.6)
-  rspec-expectations (3.13.5)
-  rspec-mocks (3.13.8)
-  rspec-support (3.13.7)
-  rubocop (1.88.2)
-  rubocop-ast (1.50.0)
-  ruby-progressbar (1.13.0)
-  securerandom (0.4.1)
-  steep (1.10.0)
-  strscan (3.1.8)
-  terminal-table (4.0.0)
-  tsort (0.2.0)
-  tzinfo (2.0.6)
-  unicode-display_width (3.2.0)
-  unicode-emoji (4.2.0)
-  uri (1.1.1)
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
+  ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
+  i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
+  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rake-compiler (1.2.9) sha256=5a3213a5dda977dfdf73e28beed6f4cd6a2cc86ac640bb662728eb7049a23607
+  rake-compiler-dock (1.11.0) sha256=eab51f2cd533eb35cea6b624a75281f047123e70a64c58b607471bb49428f8c2
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rb_sys (0.9.126) sha256=ba958e0b8b4b89eeae0b3d24b64c809eb2c37e0ab0773a49e9b1c2e22c95aef8
+  rbs (3.10.4) sha256=b17d7c4be4bb31a11a3b529830f0aa206a807ca42f2e7921a3027dfc6b7e5ce8
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  steep (1.10.0) sha256=1b295b55f9aaff1b8d3ee42453ee55bc2a1078fda0268f288edb2dc014f4d7d1
+  strscan (3.1.8) sha256=aae2db611a225559f21ffbb71765c9a4e60fd262534a9ea84f4f11c7f32f679e
+  terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH
   4.0.16

--- a/confium.gemspec
+++ b/confium.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-compiler", "~> 1.2.0"
+  spec.add_development_dependency "rake-compiler-dock", "~> 1.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 1.0"
   spec.add_development_dependency "steep", "~> 1.5"

--- a/rakelib/native_gem.rake
+++ b/rakelib/native_gem.rake
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Cross-platform native gem build via rake-compiler-dock.
+#
+# Builds pre-compiled native gems for Linux (x86_64, aarch64), macOS
+# (x86_64, arm64), and Windows (x86_64-mingw32). Consumers can then
+# `gem install confium-0.1.0-x86_64-linux` without needing a Rust
+# toolchain locally.
+#
+# Usage:
+#   bundle exec rake native_gem:all       # build all platforms
+#   bundle exec rake native_gem:x86_64-linux
+#
+# This is a v0.2.0 release-engineering step. v0.1.0 ships as a source
+# gem that requires Rust at install time.
+
+require "rake_compiler_dock"
+
+namespace :native_gem do
+  PLATFORMS = %w[
+    x86_64-linux
+    aarch64-linux
+    x86_64-darwin
+    arm64-darwin
+    x64-mingw-ucrt
+    x64-mingw32
+  ].freeze
+
+  desc "Build the source gem (no native binary)"
+  task :source do
+    sh "gem build confium.gemspec"
+  end
+
+  desc "Build native gems for all platforms via rake-compiler-dock"
+  task :all do
+    PLATFORMS.each do |platform|
+      Rake::Task["native_gem:#{platform}"].invoke
+    end
+  end
+
+  PLATFORMS.each do |platform|
+    desc "Build the native gem for #{platform}"
+    task platform do
+      RakeCompilerDock.sh <<-SH, platform: platform
+        bundle install
+        bundle exec rake native:confium_native#{platform == "x64-mingw-ucrt" ? "" : ":" + platform}
+        gem build confium.gemspec --output confium-#{platform}.gem
+      SH
+    end
+  end
+end


### PR DESCRIPTION
v0.2.0 prep: 6 platform-native gem tasks plus a source gem task.

- x86_64-linux, aarch64-linux
- x86_64-darwin, arm64-darwin
- x64-mingw-ucrt, x64-mingw32

## Usage
bundle exec rake native_gem:all  # build all 6 native gems
bundle exec rake native_gem:source  # source-only gem (v0.1.0 default)

## Test plan
- bundle exec rake -T native_gem - lists all 8 tasks
- bundle exec rspec - 77 specs pass (no regressions)