### PR TITLE
ci(release): cross-platform native gem release workflow

### DIFF
--- a/.github/workflows/release-native-gems.yml
+++ b/.github/workflows/release-native-gems.yml
@@ -1,0 +1,92 @@
+name: release-native-gems
+
+# Cross-platform native gem builder.
+#
+# Triggered on tag push (v*.*.*) — builds pre-compiled native gems for
+# Linux (x86_64/aarch64), macOS (x86_64/arm64), and Windows
+# (x64-mingw-ucrt), then publishes each to RubyGems alongside the
+# source gem.
+#
+# Local dry-run:
+#   bundle exec rake native_gem:all
+
+on:
+  push:
+    tags: [ 'v*' ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-native-gem:
+    name: native gem — ${{ matrix.platform }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - x86_64-linux
+          - aarch64-linux
+          - x86_64-darwin
+          - arm64-darwin
+          - x64-mingw-ucrt
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Set up Docker (for rake-compiler-dock)
+        uses: docker/setup-buildx-action@v7
+
+      - name: Build native gem for ${{ matrix.platform }}
+        run: bundle exec rake native_gem:${{ matrix.platform }}
+        env:
+          # rake-compiler-dock uses Docker under the hood.
+          RCD_IMAGE: rubylabs/rake-compiler-dock:1.3.0-mri-${{ matrix.platform }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-gem-${{ matrix.platform }}
+          path: confium-*.gem
+
+  build-source-gem:
+    name: source gem
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - run: bundle exec rake native_gem:source
+      - uses: actions/upload-artifact@v7
+        with:
+          name: source-gem
+          path: confium-*.gem
+
+  publish:
+    name: Publish to RubyGems
+    needs: [ build-native-gem, build-source-gem ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: gems/
+
+      - name: List gems
+        run: find gems/ -name '*.gem' -exec ls -la {} \;
+
+      - name: Publish all gems
+        run: |
+          find gems/ -name '*.gem' -print0 | while IFS= read -r -d '' gem; do
+            echo "Pushing $gem"
+            gem push "$gem"
+          done
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.CONFIUM_CI_RUBYGEMS_API_KEY }}


### PR DESCRIPTION
Triggers on tag push (v*.*.*). Builds 5 pre-compiled native gems (x86_64-linux, aarch64-linux, x86_64-darwin, arm64-darwin, x64-mingw-ucrt) via rake-compiler-dock, plus the source gem. Publishes all to RubyGems.

Pairs with the rake-compiler-dock config from #23.