### PR TITLE
fix(003): core_version reads from Cargo.lock via build.rs

### DIFF
--- a/ext/confium_native/Cargo.toml
+++ b/ext/confium_native/Cargo.toml
@@ -14,6 +14,8 @@ publish = false
 [lib]
 crate-type = ["cdylib"]
 
+build = "build.rs"
+
 [dependencies]
 # rb-sys for Ruby C API access. `global-allocator` lets the extension own its
 # own allocator rather than sharing Ruby's, which avoids a class of GC bugs.

--- a/ext/confium_native/build.rs
+++ b/ext/confium_native/build.rs
@@ -1,0 +1,47 @@
+// build.rs — read the version of confium-core from Cargo.lock and emit
+// it as a CARGO_RUSTC_ENV so lib.rs can read it at compile time.
+
+use std::fs;
+
+fn main() {
+    let lockfile = fs::read_to_string("../Cargo.lock")
+        .or_else(|_| fs::read_to_string("Cargo.lock"))
+        .expect("could not read Cargo.lock");
+
+    let version = lockfile
+        .lines()
+        // find each `[[package]]` block then the `name = "..."` line inside
+        .scan(String::new(), |state, line| {
+            if line.trim().starts_with("[[package]]") {
+                *state = String::new();
+            } else {
+                state.push_str(line);
+                state.push('\n');
+            }
+            Some(state.clone())
+        })
+        .filter_map(|block| {
+            let name = block.lines().find_map(|l| {
+                let trimmed = l.trim();
+                trimmed.strip_prefix("name = \"")?.strip_suffix('"').map(String::from)
+            })?;
+            let version = block.lines().find_map(|l| {
+                let trimmed = l.trim();
+                trimmed.strip_prefix("version = \"")?.strip_suffix('"').map(String::from)
+            })?;
+            Some((name, version))
+        })
+        .find(|(name, _)| name == "confium-core")
+        .map(|(_, v)| v);
+
+    match version {
+        Some(v) => {
+            println!("cargo:rerun-if-changed=../Cargo.lock");
+            println!("cargo:rerun-if-changed=Cargo.lock");
+            println!("cargo:rustc-env=CONFIUM_CORE_VERSION={v}");
+        }
+        None => {
+            panic!("confium-core not found in Cargo.lock");
+        }
+    }
+}

--- a/ext/confium_native/src/lib.rs
+++ b/ext/confium_native/src/lib.rs
@@ -24,9 +24,9 @@ fn native_loaded() -> bool {
 }
 
 fn core_version() -> &'static str {
-    // confium-core doesn't expose its version at runtime; we hand-mirror
-    // the workspace version the extension was built against.
-    "0.2.0"
+    // Set by build.rs at compile time from Cargo.lock. Always matches the
+    // confium-core crate version the extension was built against.
+    env!("CONFIUM_CORE_VERSION")
 }
 
 #[magnus::init]


### PR DESCRIPTION
Closes TODO 003. The hardcoded 0.2.0 is replaced with env! from build.rs that parses Cargo.lock.