### PR TITLE
feat(012-016-027): to_a + examples + DSL depth bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "confium-attributes"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a8187d302fce0a798f13b36c218646a18f4fcb4fcd1cc000dc67fcedea8acb"
+checksum = "7edc7e251d9a65d428e223ff795986e9983eff5430cc1029ddacc4451f26299a"
 dependencies = [
  "serde",
  "serde_json",

--- a/examples/composite_verify.rb
+++ b/examples/composite_verify.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Example: generate an Ed25519 keypair, sign a message as a composite
+# signature, then verify it. Run with:
+#   ruby examples/composite_verify.rb
+
+require "confium"
+
+# Generate a fresh Ed25519 keypair.
+kp = Confium::Composite.generate_ed25519_keypair
+puts "private key: 0x#{kp["private_key"].unpack1("H*")[0, 16]}..."
+puts "public key:  0x#{kp["public_key"].unpack1("H*")[0, 16]}..."
+
+# Sign a message.
+message = "hello from confium"
+component = Confium::Composite.sign_ed25519(kp["private_key"], message)
+puts "signed '#{message}' with #{component["algorithm"]}"
+
+# Build a composite signature from the single component.
+sig = Confium::Composite::Signature.new([component])
+puts "composite: #{sig.component_count} component(s), algorithms=#{sig.algorithms.inspect}"
+
+# Verify.
+result = sig.verify(message)
+puts "verification: #{result.all_verified? ? "PASS" : "FAIL"}"
+puts "per-component: #{result.per_component.inspect}"
+
+# Verify wrong message.
+bad = sig.verify("wrong message")
+puts "wrong message: #{bad.all_verified? ? "PASS" : "FAIL"} (expected FAIL)"

--- a/examples/threshold_signing.rb
+++ b/examples/threshold_signing.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Example: Shamir-split a P-256 secret across 5 parties, recover from
+# any 3, and verify the recovered secret matches. Run with:
+#   ruby examples/threshold_signing.rb
+
+require "confium"
+
+# Generate a P-256 signing keypair.
+kp = Confium::TC::FrostP256.generate_keypair
+puts "secret: 0x#{kp["private_key"].unpack1("H*")[0, 16]}..."
+
+# Split into 5 shares, threshold = 3.
+shares = Confium::TC::FrostP256.split_secret(kp["private_key"], 3, 5)
+puts "split into #{shares.size} shares, threshold = 3"
+shares.each { |s| puts "  share[#{s.x}]: 0x#{s.y_bytes.unpack1("H*")[0, 16]}..." }
+
+# Recover from any 3 of the 5.
+subset = [shares[0], shares[2], shares[4]]
+recovered = Confium::TC::FrostP256.recover_secret(
+  subset.map { |s| { "x" => s.x, "y" => s.y_bytes } }
+)
+puts "recovered from shares [0, 2, 4]: #{recovered == kp["private_key"] ? "MATCH" : "MISMATCH"}"
+
+# Try with only 2 shares (insufficient — wrong answer, not an error).
+subset2 = shares.first(2)
+recovered2 = Confium::TC::FrostP256.recover_secret(
+  subset2.map { |s| { "x" => s.x, "y" => s.y_bytes } }
+)
+puts "recovered from shares [0, 1]: #{recovered2 == kp["private_key"] ? "MATCH" : "WRONG (expected)"}"
+
+# Sign a message with the original key.
+sig = Confium::TC::FrostP256.sign(kp["private_key"], "threshold test")
+puts "signature: der.size=#{sig["der"].size}, fixed.size=#{sig["fixed"].size}"

--- a/examples/transparency_anchor.rb
+++ b/examples/transparency_anchor.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Example: anchor a string in a Merkle transparency tree and verify
+# the inclusion proof. Run with:
+#   ruby examples/transparency_anchor.rb
+
+require "confium"
+require "digest"
+
+tree = Confium::Transparency::MerkleTree.new
+
+# Anchor three "artifacts" (in practice these would be certificate DER bytes).
+artifacts = ["hello", "world", "confium"]
+artifacts.each do |a|
+  hash = Digest::SHA256.digest(a)
+  seq = tree.append(hash)
+  puts "anchored '#{a}' at sequence #{seq}"
+end
+
+puts "root: 0x#{tree.root.unpack1("H*")}"
+
+# Verify inclusion for each artifact.
+artifacts.each_with_index do |a, i|
+  hash = Digest::SHA256.digest(a)
+  proof = tree.inclusion_proof(i)
+  puts "proof[#{i}]: seq=#{proof.sequence}, steps=#{proof.steps.size}, verify=#{proof.verify(tree.root)}"
+end
+
+# Iterate via to_a.
+puts "all sequences: #{tree.to_a.map(&:sequence).inspect}"

--- a/ext/confium_native/Cargo.toml
+++ b/ext/confium_native/Cargo.toml
@@ -30,7 +30,7 @@ magnus = { version = "0.8", features = ["bytes"] }
 confium-core = "0.2"
 confium-transparency = "0.3"
 confium-composite = "0.3.1"
-confium-attributes = "0.3"
+confium-attributes = "0.3.1"
 confium-pki = "0.3.1"
 confium-deployment = "0.3"
 confium-tc-frost-p256 = "0.3"

--- a/ext/confium_native/src/transparency.rs
+++ b/ext/confium_native/src/transparency.rs
@@ -50,6 +50,19 @@ impl MerkleTree {
         self.inner.borrow().is_empty()
     }
 
+    /// Return all inclusion proofs as an Array. Use #to_a or #entries
+    /// to iterate: `tree.to_a.map(&:sequence)` etc.
+    fn entries(&self) -> Result<magnus::RArray, Error> {
+        let len = self.inner.borrow().len();
+        let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
+        let arr = ruby.ary_new_capa(len);
+        for i in 0..(len as u64) {
+            let proof = self.inclusion_proof(i)?;
+            arr.push(proof)?;
+        }
+        Ok(arr)
+    }
+
     fn root(&self) -> Value {
         let ruby = Ruby::get().expect("Ruby must be available");
         let bytes = self.inner.borrow().root();
@@ -194,6 +207,8 @@ pub fn init(ruby: &Ruby, parent: magnus::RModule) -> Result<(), Error> {
     tree_class.define_method("empty?", method!(MerkleTree::is_empty, 0))?;
     tree_class.define_method("root", method!(MerkleTree::root, 0))?;
     tree_class.define_method("inclusion_proof", method!(MerkleTree::inclusion_proof, 1))?;
+    tree_class.define_method("entries", method!(MerkleTree::entries, 0))?;
+    tree_class.define_method("to_a", method!(MerkleTree::entries, 0))?;
 
     let proof_class = transparency.define_class("InclusionProof", ruby.class_object())?;
     proof_class.define_method("sequence", method!(InclusionProofWrap::sequence, 0))?;


### PR DESCRIPTION
Batch A: TODOs 012 (entries/to_a), 016 (3 examples), 027 consumer (confium-attributes 0.3.1 dep bump).