### PR TITLE
feat(openpgp): Confium::OpenPGP optional integration via ruby-rnp

### DIFF
--- a/lib/confium.rb
+++ b/lib/confium.rb
@@ -40,4 +40,5 @@ module Confium
   autoload :SecureBytes,          "confium/secure_bytes"
   autoload :Policy,               "confium/policy"
   autoload :PKI,                  "confium/pki"
+  autoload :OpenPGP,              "confium/openpgp"
 end

--- a/lib/confium/openpgp.rb
+++ b/lib/confium/openpgp.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+# Confium::OpenPGP — optional OpenPGP (RFC 9580) integration via ruby-rnp.
+#
+# Confium handles threshold cryptography + transparency logs. RNP handles
+# standard OpenPGP (key management, signing, verification, encryption).
+# Together they provide a complete crypto stack:
+#
+#   require "confium"
+#   Confium::OpenPGP.verify(armor_signature, signed_data, public_key_armor)
+#
+# This module is a thin convenience wrapper. It lazily requires ruby-rnp
+# on first use. If ruby-rnp is not installed, methods raise a clear error
+# pointing to the install command:
+#
+#   gem install ruby-rnp
+#
+# Architecture: soft dependency pattern. The confium gem does NOT
+# hard-depend on ruby-rnp. Users who need standard OpenPGP install it
+# separately. The module detects its presence and either delegates or
+# raises a helpful error.
+
+module Confium
+  module OpenPGP
+    # Raised when ruby-rnp is not installed but an OpenPGP method is called.
+    class NotInstalledError < Confium::Error
+      def initialize
+        super("ruby-rnp is not installed. Run: gem install ruby-rnp")
+      end
+    end
+
+    @loaded = false
+    @available = false
+
+    class << self
+      # True if ruby-rnp is installed and loadable.
+      def available?
+        return @available if @loaded
+
+        @loaded = true
+        begin
+          require "rnp"
+          @available = true
+        rescue LoadError
+          @available = false
+        end
+        @available
+      end
+
+      # Ensure ruby-rnp is loaded; raise if not installed.
+      def ensure_available!
+        return if available?
+
+        raise NotInstalledError
+      end
+
+      # Verify an OpenPGP detached signature against signed data.
+      #
+      # @param signature_armor [String] Armored OpenPGP signature block.
+      # @param signed_data [String] The data that was signed.
+      # @param pubkey_armor [String] Armored public key block.
+      # @return [Boolean] true if the signature verifies.
+      # @raise [NotInstalledError] if ruby-rnp is not installed.
+      def verify(signature_armor, signed_data, pubkey_armor)
+        ensure_available!
+
+        env = Rnp.new
+        env.load_armored_pubkeys(pubkey_armor)
+
+        input_sig = Rnp::Input.from_string(signature_armor)
+        input_data = Rnp::Input.from_string(signed_data)
+        output = Rnp::Output.to_null
+
+        result = env.verify(input_sig, input_data, output)
+        result[:success]
+      end
+
+      # Sign data with an OpenPGP private key.
+      #
+      # @param data [String] Data to sign.
+      # @param key_armor [String] Armored private key block.
+      # @param password [String] Key password (empty if none).
+      # @return [String] Armored detached signature.
+      # @raise [NotInstalledError] if ruby-rnp is not installed.
+      def sign(data, key_armor, password: "")
+        ensure_available!
+
+        env = Rnp.new
+        env.load_armored_keys(key_armor, password: password)
+
+        signer = env.each_key.first
+        raise Confium::NotFoundError, "no key found in armored input" unless signer
+
+        input_data = Rnp::Input.from_string(data)
+        output_sig = Rnp::Output.to_string
+
+        op = Rnp::OpSign.new(env, input_data, output_sig)
+        op.add_signer(signer)
+        op.execute
+
+        output_sig.string
+      end
+
+      # Generate an EdDSA OpenPGP keypair.
+      #
+      # @param userid [String] User ID for the key (e.g., "Alice <alice@example.com>").
+      # @param password [String] Key protection password (empty for none).
+      # @return [String] Armored keypair (secret + public).
+      # @raise [NotInstalledError] if ruby-rnp is not installed.
+      def generate_key(userid, password: "")
+        ensure_available!
+
+        env = Rnp.new
+        keyid = env.generate_key(
+          alg: "EDDSA",
+          userid: userid,
+          password: password.empty? ? nil : password
+        )
+
+        secret = Rnp::Output.to_string
+        public_key = Rnp::Output.to_string
+        env.export_secret_key(secret, keyid: keyid)
+        env.export_public_key(public_key, keyid: keyid)
+        "#{secret.string}\n#{public_key.string}"
+      end
+
+      # Encrypt data to one or more public keys.
+      #
+      # @param data [String] Data to encrypt.
+      # @param pubkey_armor [String] Armored public key block.
+      # @return [String] Armored encrypted message.
+      # @raise [NotInstalledError] if ruby-rnp is not installed.
+      def encrypt(data, pubkey_armor)
+        ensure_available!
+
+        env = Rnp.new
+        env.load_armored_pubkeys(pubkey_armor)
+
+        recipient = env.each_key.first
+        raise Confium::NotFoundError, "no key found in armored input" unless recipient
+
+        input_data = Rnp::Input.from_string(data)
+        output = Rnp::Output.to_string
+
+        op = Rnp::OpEncrypt.new(env, input_data, output)
+        op.add_recipient(recipient)
+        op.execute
+
+        output.string
+      end
+    end
+  end
+end

--- a/spec/confium/openpgp_spec.rb
+++ b/spec/confium/openpgp_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "confium"
+
+RSpec.describe Confium::OpenPGP do
+  describe ".available?" do
+    it "returns a boolean" do
+      result = described_class.available?
+      expect([true, false]).to include(result)
+    end
+  end
+
+  describe ".ensure_available!" do
+    context "when ruby-rnp is not installed" do
+      before do
+        allow(described_class).to receive(:available?).and_return(false)
+      end
+
+      it "raises NotInstalledError with install instructions" do
+        expect { described_class.ensure_available! }.to raise_error(
+          Confium::OpenPGP::NotInstalledError, /gem install ruby-rnp/
+        )
+      end
+    end
+  end
+
+  describe ".verify" do
+    context "when ruby-rnp is not installed" do
+      before do
+        allow(described_class).to receive(:available?).and_return(false)
+      end
+
+      it "raises NotInstalledError" do
+        expect {
+          described_class.verify("sig", "data", "key")
+        }.to raise_error(Confium::OpenPGP::NotInstalledError)
+      end
+    end
+  end
+
+  describe ".sign" do
+    context "when ruby-rnp is not installed" do
+      before do
+        allow(described_class).to receive(:available?).and_return(false)
+      end
+
+      it "raises NotInstalledError" do
+        expect {
+          described_class.sign("data", "key_armor")
+        }.to raise_error(Confium::OpenPGP::NotInstalledError)
+      end
+    end
+  end
+
+  describe ".generate_key" do
+    context "when ruby-rnp is not installed" do
+      before do
+        allow(described_class).to receive(:available?).and_return(false)
+      end
+
+      it "raises NotInstalledError" do
+        expect {
+          described_class.generate_key("test@example.com")
+        }.to raise_error(Confium::OpenPGP::NotInstalledError)
+      end
+    end
+  end
+
+  describe ".encrypt" do
+    context "when ruby-rnp is not installed" do
+      before do
+        allow(described_class).to receive(:available?).and_return(false)
+      end
+
+      it "raises NotInstalledError" do
+        expect {
+          described_class.encrypt("data", "pubkey")
+        }.to raise_error(Confium::OpenPGP::NotInstalledError)
+      end
+    end
+  end
+
+  describe "NotInstalledError" do
+    it "is a subclass of Confium::Error" do
+      expect(Confium::OpenPGP::NotInstalledError.ancestors).to include(Confium::Error)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Confium::OpenPGP` — a soft-dependency wrapper around `ruby-rnp` (RNP OpenPGP, RFC 9580).

Confium handles threshold cryptography + transparency logs. RNP handles standard OpenPGP (key management, signing, verification, encryption). Together they form a complete crypto stack.

## Architecture: soft dependency

The confium gem does **NOT** hard-depend on ruby-rnp. Users who need standard OpenPGP install it separately:
```sh
gem install ruby-rnp
```

The module lazily loads ruby-rnp on first use and raises `Confium::OpenPGP::NotInstalledError` (a subclass of `Confium::Error`) if absent, with clear install instructions.

## New API

```ruby
require "confium"

Confium::OpenPGP.available?  # => true/false (was ruby-rnp loaded?)

# Verify a detached OpenPGP signature
Confium::OpenPGP.verify(armor_sig, signed_data, armor_pubkey)

# Sign data with a private key
Confium::OpenPGP.sign(data, armor_seckey, password: "secret")

# Generate an EdDSA keypair
Confium::OpenPGP.generate_key("Alice <alice@example.com>", password: "")

# Encrypt to a public key
Confium::OpenPGP.encrypt(data, armor_pubkey)
```

## Test plan

- [x] 7 new specs testing the soft-dependency pattern (available?, ensure_available!, each method raising NotInstalledError).
- [x] No `double()` — tests mock only `available?` class method, not RNP internals.
- [x] Full Ruby suite: 166 passed (up from 159).
- [x] autoload registered in `lib/confium.rb` per the no-require_relative rule.
