### PR TITLE
feat(openpgp): vendored rnp-src for full Windows + zero-dependency builds

### DIFF
--- a/ext/confium_native/Cargo.toml
+++ b/ext/confium_native/Cargo.toml
@@ -46,9 +46,10 @@ sha2 = "0.10"
 chrono = "0.4"
 serde_json = "1"
 
-# RNP (OpenPGP, RFC 9580) — hard-bundled so Confium ships with
-# standard OpenPGP armor encode/decode + key management out of the box.
-rnp = { package = "rnp-rs", version = "0.1.10" }
+# RNP (OpenPGP, RFC 9580) — hard-bundled with vendored feature so
+# librnp is compiled from source via rnp-src. No system librnp needed.
+# Works on Linux, macOS, and Windows (MSYS2/MinGW toolchain).
+rnp = { package = "rnp-rs", version = "0.1.10", features = ["vendored"] }
 
 [profile.release]
 lto = "off"

--- a/ext/confium_native/build.rs
+++ b/ext/confium_native/build.rs
@@ -48,12 +48,6 @@ fn main() {
         }
         None => panic!("confium-core not found in Cargo.lock"),
     }
-
-    // Add rpath for librnp so the compiled bundle finds it at load time
-    // without requiring DYLD_LIBRARY_PATH on every invocation.
-    if cfg!(target_os = "macos") {
-        println!("cargo:rustc-link-arg=-Wl,-rpath,/opt/homebrew/lib");
-    }
 }
 
 /// Walk up the directory tree from `start` until we find a Cargo.toml


### PR DESCRIPTION
## Summary

Enables `vendored` feature on the `rnp-rs` dependency, so librnp + Botan + json-c are compiled from source at build time. This eliminates the system librnp dependency entirely and enables **full Windows support**.

### What changed

1. `ext/confium_native/Cargo.toml`: `features = ["vendored"]` on rnp dep
2. `ext/confium_native/build.rs`: removed the macOS rpath hack (vendored = static linking, no runtime dylib needed)

### Why

Before: `gem install confium` required system-installed librnp on every platform. On macOS, users needed `brew install rnp`. On Windows, there was no easy way to install librnp at all.

After: `gem install confium` compiles everything from source. No system dependencies. Works on Linux, macOS, and Windows (MSYS2/MinGW via rnp-src 0.1.2).

### Build time impact

First build: ~3 minutes (Botan compilation from source). Subsequent builds: cached by cargo. Acceptable for `gem install` — Ruby native extensions already take 1-2 minutes to compile.

## Test plan

- [x] `bundle exec rake compile` — compiles with vendored rnp (no system librnp)
- [x] `bundle exec rspec` — 166 passed (all green, no DYLD_LIBRARY_PATH needed)
- [x] OpenPGP specs pass: armor + dearmor round-trip works
