### PR TITLE
chore(ruby): clean up unused imports and dead code in native extension

### DIFF
--- a/ext/confium_native/src/attributes.rs
+++ b/ext/confium_native/src/attributes.rs
@@ -12,7 +12,7 @@
 
 use confium_attributes::{evaluate, parse as dsl_parse, Predicate, SignerAttributes};
 use magnus::{
-    exception, function, method, prelude::*, typed_data::Obj, DataTypeFunctions, Error, Module,
+    exception, function, method, typed_data::Obj, DataTypeFunctions, Error, Module,
     Object, Ruby, TryConvert, TypedData, Value,
 };
 

--- a/ext/confium_native/src/audit.rs
+++ b/ext/confium_native/src/audit.rs
@@ -4,7 +4,7 @@
 //! Confium::Audit. The sink is a Ruby Proc that receives an audit
 //! record Hash.
 
-use magnus::{exception, function, prelude::*, Error, Module, Object, RHash, Ruby, Value};
+use magnus::{exception, function, prelude::*, Error, Module, Ruby, Value};
 
 const SINK_IVAR: &str = "@sink";
 

--- a/ext/confium_native/src/composite.rs
+++ b/ext/confium_native/src/composite.rs
@@ -12,7 +12,7 @@
 //!     with `#all_verified?` and `#per_component` accessors.
 
 use confium_composite::{CompositeSignature, ComponentSignature, VerificationResult};
-use ed25519_dalek::{Signer, SigningKey};
+use ed25519_dalek::SigningKey;
 use magnus::{
     exception, function, method, prelude::*, scan_args,
     typed_data::Obj, DataTypeFunctions, Error, IntoValue,

--- a/ext/confium_native/src/deployment.rs
+++ b/ext/confium_native/src/deployment.rs
@@ -12,7 +12,7 @@ use confium_deployment::{
     validate::validate_manifest,
 };
 use crate::util::enforce_size;
-use magnus::{exception, function, method, prelude::*, typed_data::Obj, DataTypeFunctions, Error, Module, Object, Ruby, TypedData};
+use magnus::{exception, function, method, typed_data::Obj, DataTypeFunctions, Error, Module, Object, Ruby, TypedData};
 
 #[derive(TypedData, DataTypeFunctions)]
 #[magnus(class = "Confium::Identity::Actor", size)]

--- a/ext/confium_native/src/ers.rs
+++ b/ext/confium_native/src/ers.rs
@@ -5,7 +5,7 @@ use confium_transparency::ers::{
     EvidenceRecord, HashAlgorithm,
 };
 use magnus::{
-    exception, function, method, prelude::*, typed_data::Obj,
+    exception, function, method, typed_data::Obj,
     DataTypeFunctions, Error, Module, Object, Ruby, TryConvert, TypedData, Value,
 };
 

--- a/ext/confium_native/src/openpgp.rs
+++ b/ext/confium_native/src/openpgp.rs
@@ -39,7 +39,7 @@ fn native_dearmor(ruby: &Ruby, data: Value) -> Result<magnus::RString, Error> {
 }
 
 /// Initialize the `Confium::OpenPGP` module.
-pub fn init(ruby: &Ruby, parent: RModule) -> Result<(), Error> {
+pub fn init(_ruby: &Ruby, parent: RModule) -> Result<(), Error> {
     let openpgp = parent.define_module("OpenPGP")?;
 
     openpgp.define_singleton_method("_native_armor", function!(native_armor, 2))?;

--- a/ext/confium_native/src/path.rs
+++ b/ext/confium_native/src/path.rs
@@ -10,7 +10,7 @@ use confium_pki::{
     path::{validate_path, CertPath},
     result::VerificationResult as PathVerificationResult,
 };
-use magnus::{exception, function, method, prelude::*, DataTypeFunctions, Error, Module, Object, Ruby, TypedData, Value};
+use magnus::{exception, function, method, prelude::*, DataTypeFunctions, Error, Module, Ruby, TypedData, Value};
 
 /// Wraps a confium_pki::path::VerificationResult.
 #[derive(TypedData, DataTypeFunctions)]

--- a/ext/confium_native/src/pki.rs
+++ b/ext/confium_native/src/pki.rs
@@ -205,7 +205,7 @@ impl SignedData {
     /// any standards-compliant CMS consumer.
     fn to_der(&self) -> Result<RString, Error> {
         let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
-        let der = encode_signed_data_der(&*self.inner.borrow())
+        let der = encode_signed_data_der(&self.inner.borrow())
             .map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
         Ok(bytes_to_rstring(&ruby, &der))
     }

--- a/ext/confium_native/src/tc.rs
+++ b/ext/confium_native/src/tc.rs
@@ -17,7 +17,7 @@ use confium_tc_frost_p256::{
     sign_message,
     Keypair,
 };
-use magnus::{exception, function, method, prelude::*, DataTypeFunctions, Error, Module, Object, RHash, Ruby, TryConvert, TypedData, Value};
+use magnus::{exception, function, method, DataTypeFunctions, Error, Module, RHash, Ruby, TryConvert, TypedData, Value};
 use p256::Scalar;
 
 #[derive(TypedData, DataTypeFunctions)]
@@ -93,7 +93,7 @@ fn recover(shares_value: Value) -> Result<magnus::RString, Error> {
     let secret = recover_secret(&refs)
         .map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
     let ruby = Ruby::get().map_err(|e| Error::new(exception::runtime_error(), e.to_string()))?;
-    Ok(bytes_to_rstring(&ruby, &scalar_to_bytes(&secret).to_vec()))
+    Ok(bytes_to_rstring(&ruby, scalar_to_bytes(&secret).as_ref()))
 }
 
 fn keypair(ruby: &Ruby) -> Result<RHash, Error> {
@@ -101,7 +101,7 @@ fn keypair(ruby: &Ruby) -> Result<RHash, Error> {
     let result = ruby.hash_new();
     let signing_bytes = kp.to_signing_key().to_bytes();
     let verifying_bytes = kp.to_verifying_key().to_sec1_bytes();
-    result.aset("private_key", bytes_to_rstring(ruby, &signing_bytes.to_vec()))?;
+    result.aset("private_key", bytes_to_rstring(ruby, &signing_bytes))?;
     result.aset("public_key", bytes_to_rstring(ruby, &verifying_bytes))?;
     Ok(result)
 }

--- a/ext/confium_native/src/transparency.rs
+++ b/ext/confium_native/src/transparency.rs
@@ -11,7 +11,7 @@ use confium_transparency::{
 };
 use magnus::{
     exception, function, method, prelude::*, typed_data::Obj, DataTypeFunctions, Error, IntoValue,
-    Module, Object, RHash, RString, Ruby, TryConvert, TypedData, Value,
+    Module, Object, RString, Ruby, TryConvert, TypedData, Value,
 };
 
 #[derive(TypedData, DataTypeFunctions)]

--- a/ext/confium_native/src/util.rs
+++ b/ext/confium_native/src/util.rs
@@ -112,6 +112,7 @@ pub fn new_details(ruby: &Ruby) -> RHash {
 // only the domain-specific fields; :operation and :component are
 // filled automatically.
 
+#[allow(dead_code)]
 pub fn parse_error(msg: impl Into<String>, operation: &str, format: Option<&str>, offset: Option<usize>) -> Error {
     let ruby = match Ruby::get() {
         Ok(r) => r,
@@ -125,6 +126,7 @@ pub fn parse_error(msg: impl Into<String>, operation: &str, format: Option<&str>
     confium_error(msg, "ParseError", d)
 }
 
+#[allow(dead_code)]
 pub fn validation_error(msg: impl Into<String>, operation: &str, param: &str, expected: &str, actual: &str) -> Error {
     let ruby = match Ruby::get() {
         Ok(r) => r,
@@ -138,6 +140,7 @@ pub fn validation_error(msg: impl Into<String>, operation: &str, param: &str, ex
     confium_error(msg, "ValidationError", d)
 }
 
+#[allow(dead_code)]
 pub fn verification_error(msg: impl Into<String>, operation: &str, signer_index: Option<usize>, algorithm: Option<&str>) -> Error {
     let ruby = match Ruby::get() {
         Ok(r) => r,
@@ -150,6 +153,7 @@ pub fn verification_error(msg: impl Into<String>, operation: &str, signer_index:
     confium_error(msg, "VerificationError", d)
 }
 
+#[allow(dead_code)]
 pub fn crypto_error(msg: impl Into<String>, operation: &str, primitive: &str) -> Error {
     let ruby = match Ruby::get() {
         Ok(r) => r,
@@ -161,6 +165,7 @@ pub fn crypto_error(msg: impl Into<String>, operation: &str, primitive: &str) ->
     confium_error(msg, "CryptoError", d)
 }
 
+#[allow(dead_code)]
 pub fn threshold_error(msg: impl Into<String>, operation: &str, have: usize, need: usize) -> Error {
     let ruby = match Ruby::get() {
         Ok(r) => r,


### PR DESCRIPTION
## Summary

- Pre-existing clippy warnings in the Ruby gem's Rust native extension (`confium_native`) addressed: **138 errors → 118 errors**.
- The 20 fixed errors are all real (non-deprecation) cleanups. The remaining 118 are magnus 0.8→0.9 deprecation migrations requiring Ruby context plumbing — separate workstream.

### What changed

- **Unused imports dropped**: `RHash`, `Object`, `prelude::*` gler, `Signer` trait — across 8 files (audit, attributes, composite, deployment, ers, path, tc, transparency).
- **Unnecessary conversions removed**: `.to_vec()` on already-borrowed bytes (tc.rs), explicit auto-deref `&*x → &x` (pki.rs).
- **Unused variable**: prefixed `ruby` with `_` in openpgp.rs::init.
- **Dead code marked**: 5 planned-but-not-yet-wired error helpers in util.rs (`parse_error`, `validation_error`, `verification_error`, `crypto_error`, `threshold_error`) marked `#[allow(dead_code)]`.

## Test plan

- [x] `bundle exec rake compile` — clean build (118 deprecation warnings remain)
- [x] `bundle exec rspec spec/confium/transparency_spec.rb spec/confium/composite_spec.rb` — 32 examples, 0 failures
