### PR TITLE
ci(release): publish via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-native-gems.yml
+++ b/.github/workflows/release-native-gems.yml
@@ -74,6 +74,9 @@ jobs:
     name: Publish to RubyGems
     needs: [ build-native-gem, build-source-gem ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -82,11 +85,15 @@ jobs:
       - name: List gems
         run: find gems/ -name '*.gem' -exec ls -la {} \;
 
+      # Exchange the job's OIDC token (id-token: write) for a short-lived
+      # RubyGems API key; publishes via the gem's trusted publisher
+      # (confium/confium-ruby @ release-native-gems.yml) on rubygems.org.
+      - name: Configure RubyGems credentials (trusted publishing)
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+
       - name: Publish all gems
         run: |
           find gems/ -name '*.gem' -print0 | while IFS= read -r -d '' gem; do
             echo "Pushing $gem"
             gem push "$gem"
           done
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.CONFIUM_CI_RUBYGEMS_API_KEY }}

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -61,6 +61,9 @@ jobs:
     needs: [ build-and-test, lint ]
     runs-on: ubuntu-latest
     if: contains(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v7
 
@@ -80,7 +83,11 @@ jobs:
           bundle exec rake compile
           gem build confium.gemspec
 
+      # Exchange the job's OIDC token (id-token: write) for a short-lived
+      # RubyGems API key; publishes via the gem's trusted publisher
+      # (confium/confium-ruby @ test-and-release.yml) on rubygems.org.
+      - name: Configure RubyGems credentials (trusted publishing)
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+
       - name: Publish to RubyGems
-        uses: cadwallion/publish-rubygems-action@master
-        env:
-          RUBYGEMS_API_KEY: ${{ secrets.CONFIUM_CI_RUBYGEMS_API_KEY }}
+        run: gem push confium-*.gem


### PR DESCRIPTION
## Summary
- Publishes to rubygems.org via OIDC trusted publishing in **both** release workflows:
  - `test-and-release.yml`: the third-party `cadwallion/publish-rubygems-action` (keyed on `CONFIUM_CI_RUBYGEMS_API_KEY`) is replaced by `rubygems/configure-rubygems-credentials` + `gem push`.
  - `release-native-gems.yml`: the `GEM_HOST_API_KEY` env is replaced by the same OIDC exchange step.
- `id-token: write` granted on both publishing jobs.
- The gem's trusted publishers (`confium/confium-ruby @ test-and-release.yml` and `@ release-native-gems.yml`) are already configured on rubygems.org; the repo secret can be deleted once this merges.

## Test plan
- [x] YAML parses for both workflows.
- [ ] Next `v*` tag release pushes keylessly.
